### PR TITLE
#41 feat: 마이페이지 기능 추가수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,11 +17,13 @@
         "embla-carousel-react": "^8.6.0",
         "lucide-react": "^1.8.0",
         "next": "16.2.3",
+        "next-themes": "^0.4.6",
         "radix-ui": "^1.4.3",
         "react": "19.2.4",
         "react-day-picker": "^9.14.0",
         "react-dom": "19.2.4",
         "shadcn": "^4.4.0",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0",
         "zustand": "^5.0.12"
@@ -8726,6 +8728,16 @@
         }
       }
     },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -10414,6 +10426,16 @@
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
     },
     "node_modules/source-map": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -18,11 +18,13 @@
     "embla-carousel-react": "^8.6.0",
     "lucide-react": "^1.8.0",
     "next": "16.2.3",
+    "next-themes": "^0.4.6",
     "radix-ui": "^1.4.3",
     "react": "19.2.4",
     "react-day-picker": "^9.14.0",
     "react-dom": "19.2.4",
     "shadcn": "^4.4.0",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0",
     "zustand": "^5.0.12"

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -60,9 +60,11 @@ export default function RootLayout({
         }}
       />
       <body>
-        <div className="mx-auto min-h-screen w-full max-w-(--max-width) bg-white px-5 pb-9 shadow-2xl">
+        <div className="mx-auto flex min-h-screen w-full max-w-(--max-width) flex-col bg-white px-5 pb-9 shadow-2xl">
           <Header />
-          <TooltipProvider>{children}</TooltipProvider>
+          <div className="flex flex-1 flex-col">
+            <TooltipProvider>{children}</TooltipProvider>
+          </div>
           <AlertModal />
         </div>
       </body>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { cn } from "@/lib/utils";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import AlertModal from "@/components/common/alert-modal";
 import Header from "@/components/common/header";
+import { Toaster } from "@/components/ui/sonner";
 
 export const metadata: Metadata = {
   metadataBase: new URL("https://www.musicpeak.site"),
@@ -66,6 +67,7 @@ export default function RootLayout({
             <TooltipProvider>{children}</TooltipProvider>
           </div>
           <AlertModal />
+          <Toaster position="top-center" />
         </div>
       </body>
     </html>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,7 +1,6 @@
 import { Button } from "@/components/ui/button";
 import Image from "next/image";
-import ErrorView from "@/components/common/error-view";
-import Link from "next/link";
+import LoginErrorToast from "@/components/login/login-error-toast";
 
 const BASE_URL = "https://api.musicpeak.site/oauth2/authorization";
 
@@ -12,24 +11,9 @@ export default async function Login({
 }) {
   const { error } = await searchParams;
 
-  if (error) {
-    return (
-      <main className="p-5">
-        <ErrorView
-          title="로그인에 실패했어요"
-          description="다시 시도해주세요"
-        />
-        <div className="fixed right-0 bottom-30 left-0 mx-auto max-w-(--max-width) px-11">
-          <Button asChild variant="btnPurple" size="full">
-            <Link href="/">메인으로 이동</Link>
-          </Button>
-        </div>
-      </main>
-    );
-  }
-
   return (
     <main className="p-5">
+      {error && <LoginErrorToast />}
       <div className="mt-25 mb-24 flex flex-col items-center gap-8 text-center">
         <div className="bg-grey2 flex h-44 w-44 items-center justify-center rounded-full">
           <Image src={"/bamti.svg"} alt="Logo" width={128} height={128} />

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -1,11 +1,17 @@
 "use client";
-import { Button } from "@/components/ui/button";
+
 import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import Link from "next/link";
+import { useOpenAlertModal } from "@/stores/alert-modal-store";
 
 const BASE_URL = "https://api.musicpeak.site";
 
 export default function MyPage() {
   const router = useRouter();
+  const openAlertModal = useOpenAlertModal();
+  // TODO: API 연결 시 실제 데이터로 교체
+  const hasAlbums = true;
 
   const handleLogout = async () => {
     await fetch(`${BASE_URL}/api/auth/logout`, {
@@ -15,36 +21,34 @@ export default function MyPage() {
     router.replace("/login");
   };
 
-  const handleWithdraw = async () => {
-    await fetch(`${BASE_URL}/api/me/delete`, {
-      method: "DELETE",
-      credentials: "include",
+  const handleWithdraw = () => {
+    openAlertModal({
+      type: "confirm",
+      message: "정말 탈퇴하시겠어요?\n탈퇴 후 90일간 재가입이 불가합니다.",
+      onAction: async () => {
+        await fetch(`${BASE_URL}/api/me/delete`, {
+          method: "DELETE",
+          credentials: "include",
+        });
+        router.replace("/login");
+      },
     });
-    router.replace("/login");
   };
 
   return (
-    <main className="flex flex-col gap-6 px-5 pt-10">
-      <>card component 자리</>
-      {/* 네이버검수용 프로필 나중에 지워도됨 
-      <div className="bg-grey1 flex items-center gap-4 rounded-2xl px-5 py-4">
-        <div className="bg-grey2 flex h-14 w-14 items-center justify-center rounded-full">
-          <span className="h3-bold text-font-middle">김</span>
+    <main className="flex flex-1 flex-col gap-6 px-5 pt-10">
+      {hasAlbums ? (
+        <>미리보기 컴포넌트 자리</>
+      ) : (
+        <div className="flex flex-1 flex-col items-center justify-center gap-4 text-center">
+          <p className="p2-medium text-font-middle">
+            현재 만들어진 홍보 페이지가 없어요
+          </p>
+          <Button variant="btnPurple" size="full" asChild>
+            <Link href="/album">신곡 홍보 링크 만들기</Link>
+          </Button>
         </div>
-        <div className="flex flex-col gap-1">
-          <p className="p1-bold text-font-basic">김진성</p>
-          <p className="p2-regular text-font-middle">FEAK</p>
-          <p className="c1-medium text-font-light">viviammm@naver.com</p>
-        </div>
-      </div> */}
-      <div className="flex flex-col gap-2 px-6">
-        <Button variant="btnPurple" size="full">
-          🔗 링크 복사하기
-        </Button>
-        <Button variant="btnWhite" size="full">
-          수정하기
-        </Button>
-      </div>
+      )}
 
       <div className="flex items-center justify-center">
         <button

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
 import { useOpenAlertModal } from "@/stores/alert-modal-store";
+import { toast } from "sonner";
 
 const BASE_URL = "https://api.musicpeak.site";
 
@@ -26,11 +27,19 @@ export default function MyPage() {
       type: "confirm",
       message: "정말 탈퇴하시겠어요?\n탈퇴 후 90일간 재가입이 불가합니다.",
       onAction: async () => {
-        await fetch(`${BASE_URL}/api/me/delete`, {
-          method: "DELETE",
-          credentials: "include",
-        });
-        router.replace("/login");
+        try {
+          const res = await fetch(`${BASE_URL}/api/me/delete`, {
+            method: "DELETE",
+            credentials: "include",
+          });
+          if (!res.ok) {
+            toast.error("회원탈퇴에 실패했어요. 잠시 후 다시 시도해 주세요.");
+            return;
+          }
+          router.replace("/login");
+        } catch {
+          toast.error("네트워크 오류로 회원탈퇴에 실패했어요.");
+        }
       },
     });
   };

--- a/src/components/login/login-error-toast.tsx
+++ b/src/components/login/login-error-toast.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { useEffect } from "react";
+import { toast } from "sonner";
+
+export default function LoginErrorToast() {
+  useEffect(() => {
+    toast.error("탈퇴 처리된 계정입니다. 90일 이후 재가입 가능합니다.", {
+      duration: 5000,
+    });
+  }, []);
+
+  return null;
+}

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,0 +1,49 @@
+"use client"
+
+import { useTheme } from "next-themes"
+import { Toaster as Sonner, type ToasterProps } from "sonner"
+import { CircleCheckIcon, InfoIcon, TriangleAlertIcon, OctagonXIcon, Loader2Icon } from "lucide-react"
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  const { theme = "system" } = useTheme()
+
+  return (
+    <Sonner
+      theme={theme as ToasterProps["theme"]}
+      className="toaster group"
+      icons={{
+        success: (
+          <CircleCheckIcon className="size-4" />
+        ),
+        info: (
+          <InfoIcon className="size-4" />
+        ),
+        warning: (
+          <TriangleAlertIcon className="size-4" />
+        ),
+        error: (
+          <OctagonXIcon className="size-4" />
+        ),
+        loading: (
+          <Loader2Icon className="size-4 animate-spin" />
+        ),
+      }}
+      style={
+        {
+          "--normal-bg": "var(--popover)",
+          "--normal-text": "var(--popover-foreground)",
+          "--normal-border": "var(--border)",
+          "--border-radius": "var(--radius)",
+        } as React.CSSProperties
+      }
+      toastOptions={{
+        classNames: {
+          toast: "cn-toast",
+        },
+      }}
+      {...props}
+    />
+  )
+}
+
+export { Toaster }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex. #41

<br />

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요 ( 📸 이미지 첨부 가능 )
<img width="1975" height="1162" alt="image" src="https://github.com/user-attachments/assets/2ea061d6-4ca5-48fb-ae4c-0f8b3c94b31d" />

- 마이페이지 미리보기 없을때 분기

- alert-modal 뜬뒤 탈퇴처리

- 재가입 시도 시 shadcn 토스트 노출

- 마이페이지 미리보기 있으면 embla 적용예정

- 백엔드 이슈로 날짜노출은 되어있지 않은 상태

<br />

## 💬 리뷰 요구사항 ( 선택 )

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 <br />
> ex. 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 사용자 피드백 개선을 위한 토스트 알림 시스템이 추가되었습니다.
  * 계정 삭제 시 확인 모달 창이 필수로 표시됩니다.
  * 마이페이지가 재설계되어 앨범 미리보기 및 빈 상태 메시지가 추가되었습니다.

* **개선사항**
  * 로그인 오류 처리가 개선되어 인라인 알림으로 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->