### PR TITLE
#62 hotfix: 네이버로그인 검수 마이페이지 프로필 UI 삭제

### DIFF
--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -111,17 +111,6 @@ export default function MyPage() {
 
   return (
     <main className="flex flex-1 flex-col gap-6 px-5 pt-10">
-      {/* 네이버검수용 프로필 나중에 지워도됨 */}
-      <div className="bg-grey1 flex items-center gap-4 rounded-2xl px-5 py-4">
-        <div className="bg-grey2 flex h-14 w-14 items-center justify-center rounded-full">
-          <span className="h3-bold text-font-middle">김</span>
-        </div>
-        <div className="flex flex-col gap-1">
-          <p className="p1-bold text-font-basic">김진성</p>
-          <p className="p2-regular text-font-middle">FEAK</p>
-          <p className="c1-medium text-font-light">viviammm@naver.com</p>
-        </div>
-      </div>
       {hasAlbums ? (
         <>
           <AlbumCarousel


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex. #62 

<br />

## 📝 작업 내용

<img width="1975" height="1162" alt="image" src="https://github.com/user-attachments/assets/6eff7c58-024e-4c49-964f-68f9735c1189" />
- 네이버 로그인 검수완료받아서 프로필 UI 삭제했습니다

<br />

## 💬 리뷰 요구사항 ( 선택 )

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 <br />
> ex. 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
