### PR TITLE
#65 hotfix: 구글 사용자추적 스니펫코드 추가

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -42,6 +42,17 @@ export default function RootLayout({
       className={cn(pretendard.variable, poppins.variable, "font-sans")}
     >
       <Script
+        id="gtm-snippet"
+        strategy="afterInteractive"
+        dangerouslySetInnerHTML={{
+          __html: `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-N67BVLG8');`,
+        }}
+      />
+      <Script
         id="maze-snippet"
         strategy="afterInteractive"
         dangerouslySetInnerHTML={{
@@ -61,6 +72,14 @@ export default function RootLayout({
         }}
       />
       <body>
+        <noscript>
+          <iframe
+            src="https://www.googletagmanager.com/ns.html?id=GTM-N67BVLG8"
+            height="0"
+            width="0"
+            style={{ display: "none", visibility: "hidden" }}
+          />
+        </noscript>
         <div className="mx-auto flex min-h-screen w-full max-w-(--max-width) flex-col bg-white px-5 pb-9 shadow-2xl">
           <Header />
           <div className="flex flex-1 flex-col">


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex. #65 

<br />

## 📝 작업 내용

<img width="840" height="432" alt="image" src="https://github.com/user-attachments/assets/c11733ce-397b-431c-a655-4ad7da96b1ad" />

- PM님 요청으로 해당코드 layout에 추가했습니다

<br />

## 💬 리뷰 요구사항 ( 선택 )

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 <br />
> ex. 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* Google Tag Manager 추적 기능이 통합되었습니다.
* JavaScript가 비활성화된 사용자도 분석 추적이 가능하도록 지원이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->