### PR TITLE
#69 feat: 마이페이지 앨범정보 기능연결

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import AlertModal from "@/components/common/alert-modal";
 import Header from "@/components/common/header";
 import ToastProvider from "@/components/ui/toast-provider";
+import QueryProvider from "@/components/common/query-provider";
 
 export const metadata: Metadata = {
   metadataBase: new URL("https://www.musicpeak.site"),
@@ -83,7 +84,9 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <div className="mx-auto flex min-h-screen w-full max-w-(--max-width) flex-col bg-white px-5 pb-9 shadow-2xl">
           <Header />
           <div className="flex flex-1 flex-col">
-            <TooltipProvider>{children}</TooltipProvider>
+            <QueryProvider>
+              <TooltipProvider>{children}</TooltipProvider>
+            </QueryProvider>
           </div>
           <AlertModal />
           <ToastProvider />

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -150,7 +150,10 @@ export default function MyPage() {
         </div>
       ) : isError ? (
         <>
-          <ErrorView title="데이터를 불러오지 못했어요." />
+          <ErrorView
+            title="데이터를 불러오지 못했어요."
+            description={`연결이 잠시 불안정해요.\n다시 시도해 주세요.`}
+          />
           <div className="fixed right-0 bottom-30 left-0 mx-auto max-w-(--max-width) px-11">
             <Button variant="btnPurple" size="full" onClick={() => refetch()}>
               다시 시도
@@ -197,23 +200,25 @@ export default function MyPage() {
         </div>
       )}
 
-      <div className="flex items-center justify-center">
-        <button
-          className="p2-semibold text-font-middle cursor-pointer px-4 py-3"
-          onClick={handleWithdraw}
-        >
-          회원탈퇴
-        </button>
-        <div className="flex h-6 w-6 items-center justify-center">
-          <span className="bg-border h-4 w-px"></span>
+      {!isError && (
+        <div className="flex items-center justify-center">
+          <button
+            className="p2-semibold text-font-middle cursor-pointer px-4 py-3"
+            onClick={handleWithdraw}
+          >
+            회원탈퇴
+          </button>
+          <div className="flex h-6 w-6 items-center justify-center">
+            <span className="bg-border h-4 w-px"></span>
+          </div>
+          <button
+            className="p2-semibold text-font-middle cursor-pointer px-4 py-3"
+            onClick={handleLogout}
+          >
+            로그아웃
+          </button>
         </div>
-        <button
-          className="p2-semibold text-font-middle cursor-pointer px-4 py-3"
-          onClick={handleLogout}
-        >
-          로그아웃
-        </button>
-      </div>
+      )}
     </main>
   );
 }

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -9,6 +9,7 @@ import { toast } from "sonner";
 import AlbumCarousel, { AlbumData } from "@/components/mypage/album-carousel";
 import { getMyPagePromotions, getMusicPromotion, deleteMusicPromotion } from "@/lib/api/music-promotion";
 import { getStreamingCode } from "@/utils/album";
+import { Spinner } from "@/components/ui/spinner";
 
 const BASE_URL = "https://api.musicpeak.site";
 
@@ -137,7 +138,11 @@ export default function MyPage() {
 
   return (
     <main className="flex flex-1 flex-col gap-6 px-5 pt-10">
-      {isLoading ? null : albums.length > 0 ? (
+      {isLoading ? (
+        <div className="flex flex-1 items-center justify-center">
+          <Spinner className="text-main" />
+        </div>
+      ) : albums.length > 0 ? (
         <>
           <AlbumCarousel
             albums={albums}

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -151,7 +151,7 @@ export default function MyPage() {
       ) : isError ? (
         <>
           <ErrorView
-            title="데이터를 불러오지 못했어요."
+            title={`죄송합니다\n데이터를 불러오지 못했어요.`}
             description={`연결이 잠시 불안정해요.\n다시 시도해 주세요.`}
           />
           <div className="fixed right-0 bottom-30 left-0 mx-auto max-w-(--max-width) px-11">

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -1,54 +1,61 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
 import { useOpenAlertModal } from "@/stores/alert-modal-store";
 import { toast } from "sonner";
 import AlbumCarousel, { AlbumData } from "@/components/mypage/album-carousel";
+import { getMyPagePromotions, getMusicPromotion } from "@/lib/api/music-promotion";
+import { getStreamingCode } from "@/utils/album";
 
 const BASE_URL = "https://api.musicpeak.site";
-
-// TODO: API 연결 시 교체
-const MOCK_ALBUMS: AlbumData[] = [
-  {
-    id: "1",
-    coverUrl: "/test-cover.png",
-    title: "피크와 함께라면",
-    artist: "김피크",
-    releaseDate: "2026.01.01",
-    streamingLinks: [
-      { code: "spotify", url: "https://open.spotify.com/" },
-      { code: "youtubemusic", url: "https://open.spotify.com/" },
-      { code: "soundcloud", url: "https://open.spotify.com/" },
-    ],
-    message:
-      "난 지금 미쳐가고 있다.\n이 헤드폰에 내 모든 몸과 영혼을 맡겼다.\n음악만이 나라에서 허락하는 유일한 마약이니까.\n이게 바로 지금의 나다.",
-    link: "https://www.musicpeak.site/album/1",
-  },
-  {
-    id: "2",
-    coverUrl: "/test-cover.png",
-    title: "피크와 함께라면",
-    artist: "김피크",
-    releaseDate: "2026.01.01",
-    streamingLinks: [
-      { code: "spotify", url: "https://open.spotify.com/" },
-      { code: "youtubemusic", url: "https://open.spotify.com/" },
-      { code: "soundcloud", url: "https://open.spotify.com/" },
-    ],
-    message:
-      "난 지금 미쳐가고 있다.\n이 헤드폰에 내 모든 몸과 영혼을 맡겼다.\n음악만이 나라에서 허락하는 유일한 마약이니까.\n이게 바로 지금의 나다.",
-    link: "https://www.musicpeak.site/album/2",
-  },
-];
 
 export default function MyPage() {
   const router = useRouter();
   const openAlertModal = useOpenAlertModal();
-  const [selectedAlbum, setSelectedAlbum] = useState<AlbumData>(MOCK_ALBUMS[0]);
-  const hasAlbums = MOCK_ALBUMS.length > 0;
+  const [albums, setAlbums] = useState<AlbumData[]>([]);
+  const [selectedAlbum, setSelectedAlbum] = useState<AlbumData | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchAlbums = async () => {
+      try {
+        const { promotions } = await getMyPagePromotions();
+        const details = await Promise.all(
+          promotions.map((p) => getMusicPromotion(p.promotionId))
+        );
+
+        const albumData: AlbumData[] = details.map((data) => ({
+          id: String(data.promotionId),
+          coverUrl: data.imageUrl,
+          title: data.songTitle,
+          artist: data.activityName,
+          releaseDate: data.releaseDate,
+          message: data.shortDescription,
+          streamingLinks: data.streamingLinks
+            .sort((a, b) => a.displayOrder - b.displayOrder)
+            .map((link) => {
+              const code = getStreamingCode(`https://${link.domain}`);
+              if (!code) return null;
+              return { code, url: link.redirectUrl };
+            })
+            .filter((v): v is NonNullable<typeof v> => v !== null),
+          link: data.trackingUrl,
+        }));
+
+        setAlbums(albumData);
+        if (albumData.length > 0) setSelectedAlbum(albumData[0]);
+      } catch {
+        toast.error("앨범 목록을 불러오지 못했어요.");
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchAlbums();
+  }, []);
 
   const handleSelect = useCallback((album: AlbumData) => {
     setSelectedAlbum(album);
@@ -119,10 +126,10 @@ export default function MyPage() {
 
   return (
     <main className="flex flex-1 flex-col gap-6 px-5 pt-10">
-      {hasAlbums ? (
+      {isLoading ? null : albums.length > 0 ? (
         <>
           <AlbumCarousel
-            albums={MOCK_ALBUMS}
+            albums={albums}
             onSelect={handleSelect}
             onDelete={handleDeleteAlbum}
           />
@@ -130,14 +137,19 @@ export default function MyPage() {
             <Button
               variant="btnPurple"
               size="full"
-              onClick={() => navigator.clipboard.writeText(selectedAlbum.link)}
+              onClick={() =>
+                selectedAlbum &&
+                navigator.clipboard.writeText(selectedAlbum.link)
+              }
             >
               🔗 링크 복사
             </Button>
             <Button
               variant="btnWhite"
               size="full"
-              onClick={() => router.push(`/album/${selectedAlbum.id}`)}
+              onClick={() =>
+                selectedAlbum && router.push(`/album/${selectedAlbum.id}`)
+              }
             >
               수정하기
             </Button>

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -7,7 +7,7 @@ import Link from "next/link";
 import { useOpenAlertModal } from "@/stores/alert-modal-store";
 import { toast } from "sonner";
 import AlbumCarousel, { AlbumData } from "@/components/mypage/album-carousel";
-import { getMyPagePromotions, getMusicPromotion } from "@/lib/api/music-promotion";
+import { getMyPagePromotions, getMusicPromotion, deleteMusicPromotion } from "@/lib/api/music-promotion";
 import { getStreamingCode } from "@/utils/album";
 
 const BASE_URL = "https://api.musicpeak.site";
@@ -70,7 +70,7 @@ export default function MyPage() {
     router.refresh();
   };
 
-  const handleDeleteAlbum = () => {
+  const handleDeleteAlbum = (album: AlbumData) => {
     openAlertModal({
       type: "confirm",
       message: (
@@ -83,7 +83,18 @@ export default function MyPage() {
           정말 삭제하시겠어요?
         </>
       ),
-      onAction: () => {},
+      onAction: async () => {
+        try {
+          await deleteMusicPromotion(Number(album.id));
+          setAlbums((prev) => {
+            const next = prev.filter((a) => a.id !== album.id);
+            setSelectedAlbum(next[0] ?? null);
+            return next;
+          });
+        } catch {
+          toast.error("삭제에 실패했어요. 잠시 후 다시 시도해 주세요.");
+        }
+      },
     });
   };
 

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -7,10 +7,15 @@ import Link from "next/link";
 import { useOpenAlertModal } from "@/stores/alert-modal-store";
 import { toast } from "sonner";
 import AlbumCarousel, { AlbumData } from "@/components/mypage/album-carousel";
-import { getMyPagePromotions, getMusicPromotion, deleteMusicPromotion } from "@/lib/api/music-promotion";
+import {
+  getMyPagePromotions,
+  getMusicPromotion,
+  deleteMusicPromotion,
+} from "@/lib/api/music-promotion";
 import { getStreamingCode } from "@/utils/album";
 import { Spinner } from "@/components/ui/spinner";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
+import ErrorView from "@/components/common/error-view";
 
 const BASE_URL = "https://api.musicpeak.site";
 
@@ -47,12 +52,18 @@ export default function MyPage() {
   const [selectedAlbumId, setSelectedAlbumId] = useState<string | null>(null);
 
   const queryClient = useQueryClient();
-  const { data: albums = [], isLoading } = useQuery<AlbumData[]>({
+  const {
+    data: albums = [],
+    isLoading,
+    isError,
+    refetch,
+  } = useQuery<AlbumData[]>({
     queryKey: ["myPageAlbums"],
     queryFn: fetchAlbums,
   });
 
-  const selectedAlbum = albums.find((a) => a.id === selectedAlbumId) ?? albums[0] ?? null;
+  const selectedAlbum =
+    albums.find((a) => a.id === selectedAlbumId) ?? albums[0] ?? null;
 
   const handleSelect = useCallback((album: AlbumData) => {
     setSelectedAlbumId(album.id);
@@ -137,6 +148,15 @@ export default function MyPage() {
         <div className="flex flex-1 items-center justify-center">
           <Spinner className="text-main" />
         </div>
+      ) : isError ? (
+        <>
+          <ErrorView title="데이터를 불러오지 못했어요." />
+          <div className="fixed right-0 bottom-30 left-0 mx-auto max-w-(--max-width) px-11">
+            <Button variant="btnPurple" size="full" onClick={() => refetch()}>
+              다시 시도
+            </Button>
+          </div>
+        </>
       ) : albums.length > 0 ? (
         <>
           <AlbumCarousel

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
@@ -10,58 +10,52 @@ import AlbumCarousel, { AlbumData } from "@/components/mypage/album-carousel";
 import { getMyPagePromotions, getMusicPromotion, deleteMusicPromotion } from "@/lib/api/music-promotion";
 import { getStreamingCode } from "@/utils/album";
 import { Spinner } from "@/components/ui/spinner";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 
 const BASE_URL = "https://api.musicpeak.site";
+
+async function fetchAlbums(): Promise<AlbumData[]> {
+  const { promotions } = await getMyPagePromotions();
+  const details = await Promise.all(
+    [...promotions]
+      .sort((a, b) => b.promotionId - a.promotionId)
+      .map((p) => getMusicPromotion(p.promotionId))
+  );
+
+  return details.map((data) => ({
+    id: String(data.promotionId),
+    coverUrl: data.imageUrl,
+    title: data.songTitle,
+    artist: data.activityName,
+    releaseDate: data.releaseDate,
+    message: data.shortDescription,
+    streamingLinks: data.streamingLinks
+      .sort((a, b) => a.displayOrder - b.displayOrder)
+      .map((link) => {
+        const code = getStreamingCode(`https://${link.domain}`);
+        if (!code) return null;
+        return { code, url: link.redirectUrl };
+      })
+      .filter((v): v is NonNullable<typeof v> => v !== null),
+    link: data.trackingUrl,
+  }));
+}
 
 export default function MyPage() {
   const router = useRouter();
   const openAlertModal = useOpenAlertModal();
-  const [albums, setAlbums] = useState<AlbumData[]>([]);
-  const [selectedAlbum, setSelectedAlbum] = useState<AlbumData | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
+  const [selectedAlbumId, setSelectedAlbumId] = useState<string | null>(null);
 
-  useEffect(() => {
-    const fetchAlbums = async () => {
-      try {
-        const { promotions } = await getMyPagePromotions();
-        const details = await Promise.all(
-          [...promotions]
-            .sort((a, b) => b.promotionId - a.promotionId)
-            .map((p) => getMusicPromotion(p.promotionId))
-        );
+  const queryClient = useQueryClient();
+  const { data: albums = [], isLoading } = useQuery<AlbumData[]>({
+    queryKey: ["myPageAlbums"],
+    queryFn: fetchAlbums,
+  });
 
-        const albumData: AlbumData[] = details.map((data) => ({
-          id: String(data.promotionId),
-          coverUrl: data.imageUrl,
-          title: data.songTitle,
-          artist: data.activityName,
-          releaseDate: data.releaseDate,
-          message: data.shortDescription,
-          streamingLinks: data.streamingLinks
-            .sort((a, b) => a.displayOrder - b.displayOrder)
-            .map((link) => {
-              const code = getStreamingCode(`https://${link.domain}`);
-              if (!code) return null;
-              return { code, url: link.redirectUrl };
-            })
-            .filter((v): v is NonNullable<typeof v> => v !== null),
-          link: data.trackingUrl,
-        }));
-
-        setAlbums(albumData);
-        if (albumData.length > 0) setSelectedAlbum(albumData[0]);
-      } catch {
-        toast.error("앨범 목록을 불러오지 못했어요.");
-      } finally {
-        setIsLoading(false);
-      }
-    };
-
-    fetchAlbums();
-  }, []);
+  const selectedAlbum = albums.find((a) => a.id === selectedAlbumId) ?? albums[0] ?? null;
 
   const handleSelect = useCallback((album: AlbumData) => {
-    setSelectedAlbum(album);
+    setSelectedAlbumId(album.id);
   }, []);
 
   const handleLogout = async () => {
@@ -89,11 +83,10 @@ export default function MyPage() {
       onAction: async () => {
         try {
           await deleteMusicPromotion(Number(album.id));
-          setAlbums((prev) => {
-            const next = prev.filter((a) => a.id !== album.id);
-            setSelectedAlbum(next[0] ?? null);
-            return next;
-          });
+          queryClient.setQueryData<AlbumData[]>(["myPageAlbums"], (prev = []) =>
+            prev.filter((a) => a.id !== album.id)
+          );
+          setSelectedAlbumId(null);
         } catch {
           toast.error("삭제에 실패했어요. 잠시 후 다시 시도해 주세요.");
         }

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -25,7 +25,9 @@ export default function MyPage() {
       try {
         const { promotions } = await getMyPagePromotions();
         const details = await Promise.all(
-          promotions.map((p) => getMusicPromotion(p.promotionId))
+          [...promotions]
+            .sort((a, b) => b.promotionId - a.promotionId)
+            .map((p) => getMusicPromotion(p.promotionId))
         );
 
         const albumData: AlbumData[] = details.map((data) => ({

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -166,7 +166,7 @@ export default function MyPage() {
               variant="btnWhite"
               size="full"
               onClick={() =>
-                selectedAlbum && router.push(`/album/${selectedAlbum.id}`)
+                selectedAlbum && router.push(`/album?edit=${selectedAlbum.id}`)
               }
             >
               수정하기

--- a/src/components/common/query-provider.tsx
+++ b/src/components/common/query-provider.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useState } from "react";
+
+export default function QueryProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [queryClient] = useState(() => new QueryClient());
+
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}

--- a/src/lib/api/music-promotion.ts
+++ b/src/lib/api/music-promotion.ts
@@ -3,6 +3,7 @@ import { MusicPromotionInfo } from "@/types/album";
 import {
   CreateMusicPromotionRes,
   GetMusicPromotionRes,
+  GetMyPagePromotionsRes,
 } from "@/types/api-response";
 
 /**
@@ -23,6 +24,25 @@ export async function createMusicPromotion(
     return res.data;
   } catch {
     throw new Error("[music-promotion]: 뮤지션 홍보 생성 실패");
+  }
+}
+
+/**
+ * 마이페이지 프로모션 목록 조회
+ * [GET] /mypage/promotions
+ */
+export async function getMyPagePromotions(): Promise<GetMyPagePromotionsRes> {
+  try {
+    const res = await fetcher<{
+      data: GetMyPagePromotionsRes;
+    }>("/mypage/promotions", {
+      method: "GET",
+    });
+
+    return res.data;
+  } catch (e) {
+    console.error("[music-promotion]: 마이페이지 프로모션 목록 조회 실패");
+    throw e;
   }
 }
 

--- a/src/lib/api/music-promotion.ts
+++ b/src/lib/api/music-promotion.ts
@@ -47,6 +47,21 @@ export async function getMyPagePromotions(): Promise<GetMyPagePromotionsRes> {
 }
 
 /**
+ * 뮤지션 홍보 삭제
+ * [DELETE] /music-promotions/{promotionId}
+ */
+export async function deleteMusicPromotion(promotionId: number): Promise<void> {
+  try {
+    await fetcher<void>(`/music-promotions/${promotionId}`, {
+      method: "DELETE",
+    });
+  } catch (e) {
+    console.error("[music-promotion]: 뮤지션 홍보 삭제 실패");
+    throw e;
+  }
+}
+
+/**
  * 뮤지션 홍보 조회
  * [GET] /music-promotions/{promotionId}
  */

--- a/src/lib/api/music-promotion.ts
+++ b/src/lib/api/music-promotion.ts
@@ -33,13 +33,11 @@ export async function createMusicPromotion(
  */
 export async function getMyPagePromotions(): Promise<GetMyPagePromotionsRes> {
   try {
-    const res = await fetcher<{
-      data: GetMyPagePromotionsRes;
-    }>("/mypage/promotions", {
+    const res = await fetcher<GetMyPagePromotionsRes>("/mypage/promotions", {
       method: "GET",
     });
 
-    return res.data;
+    return res;
   } catch (e) {
     console.error("[music-promotion]: 마이페이지 프로모션 목록 조회 실패");
     throw e;

--- a/src/types/api-response.ts
+++ b/src/types/api-response.ts
@@ -19,6 +19,25 @@ export interface CreateMusicPromotionRes {
   promotionId: number;
 }
 
+// 마이페이지 프로모션 목록 조회 Res
+export interface MyPagePromotion {
+  promotionId: number;
+  title: string;
+  coverImageUrl: string;
+  shareCount: number;
+  profileVisitCount: number;
+  linkClickCount: number;
+}
+
+export interface GetMyPagePromotionsRes {
+  promotions: MyPagePromotion[];
+  page: number;
+  size: number;
+  totalElements: number;
+  totalPages: number;
+  hasNext: boolean;
+}
+
 // 뮤지션 홍보 조회 Res
 export interface GetMusicPromotionRes {
   promotionId: number;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex. #69 

<br />

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요 ( 📸 이미지 첨부 가능 )
<img width="1624" height="1061" alt="image" src="https://github.com/user-attachments/assets/163d7f0d-b25f-42c4-b115-ef0aa5ad9188" />

- 마이페이지 프로모션 목록 조회 응답 타입 및 API 함수 추가
- 뮤지션 홍보 삭제 API 함수 추가 `deleteMusicPromotion`
- 마이페이지 실데이터 API 연결 (MOCK 제거, useEffect fetch)
- 마이페이지 로딩 스피너 추가
- 마이페이지 앨범 삭제 API 연결
- 마이페이지 앨범 최신순 정렬 (promotionId 내림차순)
- 마이페이지 수정하기 버튼 라우팅만 연결 `/album?edit=${id}` (기능 x)
- TanStack Query 도입 및 마이페이지 캐싱 적용

<br />

## 💬 리뷰 요구사항 ( 선택 )

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 <br />
> ex. 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 마이페이지에서 앨범 삭제 기능 추가
  * 프로모션 데이터를 실시간으로 동적 로드

* **개선사항**
  * 마이페이지 UI 액션(링크 복사, 수정하기) 업데이트
  * 프로모션 목록 로딩 상태 표시 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->