### PR TITLE
#79 fix: 로그인 툴팁 위치 고정 및 에러페이지 버튼 위치 수정

### DIFF
--- a/src/app/(default)/login/page.tsx
+++ b/src/app/(default)/login/page.tsx
@@ -54,7 +54,7 @@ export default function Login() {
           asChild
           variant="btnWhite"
           size="full"
-          className="border-none bg-[#03CF5D] text-[#ffffff]"
+          className="text-font-white border-none bg-[#03CF5D]"
         >
           <a href={`${BASE_URL}/naver`}>
             <Image src={"/naver.png"} alt="Naver Logo" width={30} height={30} />

--- a/src/app/(default)/mypage/page.tsx
+++ b/src/app/(default)/mypage/page.tsx
@@ -155,14 +155,11 @@ export default function MyPage() {
       ) : isError ? (
         <>
           <ErrorView
-            title={`죄송합니다\n데이터를 불러오지 못했어요.`}
-            description={`연결이 잠시 불안정해요.\n다시 시도해 주세요.`}
+            title={`요청하신 화면을\n불러오지 못했어요`}
+            description={`페이지가 없거나 연결이 잠시 불안정해요.\n잠시 후 다시 시도해주세요.`}
+            onAction={refetch}
+            actionLabel="다시 시도하기"
           />
-          <div className="fixed right-0 bottom-30 left-0 mx-auto max-w-(--max-width) px-11">
-            <Button variant="btnPurple" size="full" onClick={() => refetch()}>
-              다시 시도
-            </Button>
-          </div>
         </>
       ) : albums.length > 0 ? (
         <>

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,19 +1,10 @@
 import ErrorView from "@/components/common/error-view";
-import { Button } from "@/components/ui/button";
-import Link from "next/link";
 
 export default function NotFound() {
   return (
-    <main className="p-5">
-      <ErrorView
-        title={`요청하신 화면을\n불러오지 못했어요`}
-        description={`페이지가 없거나 연결이 잠시 불안정해요.\n잠시 후 다시 시도해주세요.`}
-      />
-      <div className="fixed right-0 bottom-30 left-0 mx-auto max-w-(--max-width) px-11">
-        <Button asChild variant="btnPurple" size="full">
-          <Link href="/">메인으로 이동</Link>
-        </Button>
-      </div>
-    </main>
+    <ErrorView
+      title={`요청하신 화면을\n불러오지 못했어요`}
+      description={`페이지가 없거나 연결이 잠시 불안정해요.\n잠시 후 다시 시도해주세요.`}
+    />
   );
 }

--- a/src/components/common/error-view.tsx
+++ b/src/components/common/error-view.tsx
@@ -17,7 +17,7 @@ export default function ErrorView({
   linkHref = "/",
   linkLabel = "메인으로 이동",
   onAction,
-  actionLabel,
+  actionLabel = "다시 시도",
 }: ErrorViewProps) {
   return (
     <div className="flex min-h-screen flex-col items-center justify-around text-center whitespace-pre-line">

--- a/src/components/common/error-view.tsx
+++ b/src/components/common/error-view.tsx
@@ -1,22 +1,46 @@
 import Image from "next/image";
+import { Button } from "@/components/ui/button";
+import Link from "next/link";
 
 interface ErrorViewProps {
   title: string;
   description?: string;
+  linkHref?: string;
+  linkLabel?: string;
+  onAction?: () => void;
+  actionLabel?: string;
 }
 
-export default function ErrorView({ title, description }: ErrorViewProps) {
+export default function ErrorView({
+  title,
+  description,
+  linkHref = "/",
+  linkLabel = "메인으로 이동",
+  onAction,
+  actionLabel,
+}: ErrorViewProps) {
   return (
-    <div className="mt-25 flex flex-col items-center gap-8 text-center whitespace-pre-line">
-      <div className="flex flex-col gap-14">
-        <h1 className="h1-bold">{title}</h1>
-        {description && (
-          <p className="text-font-middle p2-regular">{description}</p>
-        )}
+    <div className="flex min-h-screen flex-col items-center justify-between pt-25 text-center whitespace-pre-line">
+      <div className="flex flex-col items-center gap-8">
+        <div className="flex flex-col gap-14">
+          <h1 className="h1-bold">{title}</h1>
+          {description && (
+            <p className="text-font-middle p2-regular">{description}</p>
+          )}
+        </div>
+        <div className="bg-grey2 flex h-44 w-44 items-center justify-center rounded-full">
+          <Image src={"/bamti-sad.svg"} alt="" width={128} height={128} />
+        </div>
       </div>
-      <div className="bg-grey2 flex h-44 w-44 items-center justify-center rounded-full">
-        <Image src={"/bamti-sad.svg"} alt="" width={128} height={128} />
-      </div>
+      {onAction ? (
+        <Button variant="btnPurple" size="full" onClick={onAction}>
+          {actionLabel}
+        </Button>
+      ) : (
+        <Button asChild variant="btnPurple" size="full">
+          <Link href={linkHref}>{linkLabel}</Link>
+        </Button>
+      )}
     </div>
   );
 }

--- a/src/components/common/error-view.tsx
+++ b/src/components/common/error-view.tsx
@@ -20,7 +20,7 @@ export default function ErrorView({
   actionLabel,
 }: ErrorViewProps) {
   return (
-    <div className="flex min-h-screen flex-col items-center justify-between pt-25 text-center whitespace-pre-line">
+    <div className="flex min-h-screen flex-col items-center justify-around text-center whitespace-pre-line">
       <div className="flex flex-col items-center gap-8">
         <div className="flex flex-col gap-14">
           <h1 className="h1-bold">{title}</h1>

--- a/src/components/home/home-buttons.tsx
+++ b/src/components/home/home-buttons.tsx
@@ -73,7 +73,7 @@ export default function HomeButtons({ isLoggedIn }: { isLoggedIn: boolean }) {
               내 음원 홍보 진단하기
             </Button>
           </TooltipTrigger>
-          <TooltipContent side="bottom">
+          <TooltipContent side="bottom" avoidCollisions={false}>
             <p>
               지금 <strong>팬이 왜 안 늘고 있는지</strong>,
               <br />


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex. #79 

<br />

## 📝 작업 내용

<img width="635" height="858" alt="image" src="https://github.com/user-attachments/assets/6d959da9-3f1b-4355-9020-01c0466a2c72" />|<img width="433" height="583" alt="image" src="https://github.com/user-attachments/assets/4a4d45e4-1a49-4b17-b94b-22904c792aca" />---|---|

- `ErrorView` 컴포넌트에 `onAction` / `actionLabel` props 추가 (링크 대신 버튼 콜백 지원)

- 홈 두 번째 툴팁 `avoidCollisions={false}` 추가 (공간 부족 시 위로 뒤집히던 현상 수정)

<br />

## 💬 리뷰 요구사항 ( 선택 )

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 <br />
> ex. 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **스타일**
  * 로그인 버튼의 텍스트 색상 스타일 업데이트
  * 툴팁 표시 동작 최적화

* **개선 사항**
  * 에러 화면에 재시도 및 링크 기능 추가
  * 오류 페이지 UI 단순화 및 개선
  * 에러 뷰 컴포넌트의 유연성 향상으로 더 나은 사용자 안내 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->