### PR TITLE
#61 refactor: 플래시 현상 및 auth 구조 개선

### DIFF
--- a/src/app/(default)/auth/success/page.tsx
+++ b/src/app/(default)/auth/success/page.tsx
@@ -10,7 +10,7 @@ export default function AuthSuccess() {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), 10_000);
 
-    fetch("https://api.musicpeak.site/api/me", {
+    fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/me`, {
       credentials: "include",
       signal: controller.signal,
     })

--- a/src/app/(default)/mypage/page.tsx
+++ b/src/app/(default)/mypage/page.tsx
@@ -147,6 +147,7 @@ export default function MyPage() {
             toast.error("회원탈퇴에 실패했어요. 잠시 후 다시 시도해 주세요.");
             return;
           }
+          document.cookie = "onboarding=; path=/; max-age=0";
           router.replace("/onboarding");
           router.refresh();
         } catch {

--- a/src/app/(default)/mypage/page.tsx
+++ b/src/app/(default)/mypage/page.tsx
@@ -17,7 +17,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import ErrorView from "@/components/common/error-view";
 
-const BASE_URL = "https://api.musicpeak.site";
+const BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
 
 async function fetchAlbums(): Promise<AlbumData[]> {
   const { promotions } = await getMyPagePromotions();

--- a/src/app/(default)/mypage/page.tsx
+++ b/src/app/(default)/mypage/page.tsx
@@ -84,7 +84,7 @@ export default function MyPage() {
   };
 
   const handleLogout = async () => {
-    await fetch(`${BASE_URL}/api/auth/logout`, {
+    await fetch(`${BASE_URL}/auth/logout`, {
       method: "POST",
       credentials: "include",
     });
@@ -139,7 +139,7 @@ export default function MyPage() {
       ),
       onAction: async () => {
         try {
-          const res = await fetch(`${BASE_URL}/api/me/delete`, {
+          const res = await fetch(`${BASE_URL}/me/delete`, {
             method: "DELETE",
             credentials: "include",
           });

--- a/src/app/(default)/onboarding/page.tsx
+++ b/src/app/(default)/onboarding/page.tsx
@@ -53,7 +53,7 @@ export default function OnboardingPage() {
   const scrollTo = (index: number) => emblaApi?.scrollTo(index);
 
   const handleFinish = () => {
-    localStorage.setItem("onboarding", "done");
+    document.cookie = "onboarding=done; path=/; max-age=31536000";
     router.push("/login");
   };
   const handleNext = () => {

--- a/src/app/(default)/page.tsx
+++ b/src/app/(default)/page.tsx
@@ -1,10 +1,17 @@
 import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
 import HomeButtons from "@/components/home/home-buttons";
 import Image from "next/image";
 
 export default async function Home() {
   const cookieStore = await cookies();
+
+  if (!cookieStore.has("onboarding")) {
+    redirect("/onboarding");
+  }
+
   const isLoggedIn = cookieStore.has("refreshToken");
+  const showIntro = !cookieStore.has("peak-intro-seen");
 
   return (
     <main className="p-5">
@@ -26,7 +33,7 @@ export default async function Home() {
           </p>
         </div>
       </div>
-      <HomeButtons isLoggedIn={isLoggedIn} />
+      <HomeButtons isLoggedIn={isLoggedIn} showIntro={showIntro} />
     </main>
   );
 }

--- a/src/app/(default)/page.tsx
+++ b/src/app/(default)/page.tsx
@@ -5,7 +5,6 @@ import Image from "next/image";
 export default async function Home() {
   const cookieStore = await cookies();
 
-  const isLoggedIn = cookieStore.has("refreshToken");
   const showIntro = !cookieStore.has("peak-intro-seen");
 
   return (
@@ -28,7 +27,7 @@ export default async function Home() {
           </p>
         </div>
       </div>
-      <HomeButtons isLoggedIn={isLoggedIn} showIntro={showIntro} />
+      <HomeButtons showIntro={showIntro} />
     </main>
   );
 }

--- a/src/app/(default)/page.tsx
+++ b/src/app/(default)/page.tsx
@@ -1,14 +1,9 @@
 import { cookies } from "next/headers";
-import { redirect } from "next/navigation";
 import HomeButtons from "@/components/home/home-buttons";
 import Image from "next/image";
 
 export default async function Home() {
   const cookieStore = await cookies();
-
-  if (!cookieStore.has("onboarding")) {
-    redirect("/onboarding");
-  }
 
   const isLoggedIn = cookieStore.has("refreshToken");
   const showIntro = !cookieStore.has("peak-intro-seen");

--- a/src/components/home/home-buttons.tsx
+++ b/src/components/home/home-buttons.tsx
@@ -9,27 +9,13 @@ import {
   TooltipContent,
 } from "@/components/ui/tooltip";
 
-export default function HomeButtons({
-  isLoggedIn,
-  showIntro,
-}: {
-  isLoggedIn: boolean;
-  showIntro: boolean;
-}) {
+export default function HomeButtons({ showIntro }: { showIntro: boolean }) {
   const [showIntroState, setShowIntroState] = useState(showIntro);
   const router = useRouter();
 
   const dismissIntro = () => {
     document.cookie = "peak-intro-seen=true; path=/; max-age=31536000";
     setShowIntroState(false);
-  };
-
-  const handleCta = (path: string) => {
-    if (!isLoggedIn) {
-      router.push("/login");
-      return;
-    }
-    router.push(path);
   };
 
   return (
@@ -46,7 +32,7 @@ export default function HomeButtons({
             <Button
               variant="btnPurple"
               size="full"
-              onClick={() => handleCta("/album")}
+              onClick={() => router.push("/album")}
             >
               신곡 홍보 링크 만들기
             </Button>
@@ -64,7 +50,7 @@ export default function HomeButtons({
             <Button
               variant="btnWhite"
               size="full"
-              onClick={() => handleCta("/report")}
+              onClick={() => router.push("/report")}
             >
               내 음원 홍보 진단하기
             </Button>

--- a/src/components/home/home-buttons.tsx
+++ b/src/components/home/home-buttons.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import {
@@ -9,23 +9,19 @@ import {
   TooltipContent,
 } from "@/components/ui/tooltip";
 
-export default function HomeButtons({ isLoggedIn }: { isLoggedIn: boolean }) {
-  const [showIntro, setShowIntro] = useState(false);
+export default function HomeButtons({
+  isLoggedIn,
+  showIntro,
+}: {
+  isLoggedIn: boolean;
+  showIntro: boolean;
+}) {
+  const [showIntroState, setShowIntroState] = useState(showIntro);
   const router = useRouter();
 
-  useEffect(() => {
-    if (!localStorage.getItem("onboarding")) {
-      router.replace("/onboarding");
-      return;
-    }
-    if (!localStorage.getItem("peak-intro-seen")) {
-      setShowIntro(true);
-    }
-  }, [router]);
-
   const dismissIntro = () => {
-    localStorage.setItem("peak-intro-seen", "true");
-    setShowIntro(false);
+    document.cookie = "peak-intro-seen=true; path=/; max-age=31536000";
+    setShowIntroState(false);
   };
 
   const handleCta = (path: string) => {
@@ -38,14 +34,14 @@ export default function HomeButtons({ isLoggedIn }: { isLoggedIn: boolean }) {
 
   return (
     <>
-      {showIntro && (
+      {showIntroState && (
         <div
           className="fixed inset-0 z-1000 bg-black/50"
           onClick={dismissIntro}
         />
       )}
       <div className="flex flex-col gap-4">
-        <Tooltip open={showIntro}>
+        <Tooltip open={showIntroState}>
           <TooltipTrigger asChild>
             <Button
               variant="btnPurple"
@@ -63,7 +59,7 @@ export default function HomeButtons({ isLoggedIn }: { isLoggedIn: boolean }) {
             </p>
           </TooltipContent>
         </Tooltip>
-        <Tooltip open={showIntro}>
+        <Tooltip open={showIntroState}>
           <TooltipTrigger asChild>
             <Button
               variant="btnWhite"

--- a/src/lib/api/common.ts
+++ b/src/lib/api/common.ts
@@ -10,13 +10,29 @@ export function getAccessToken() {
   return localStorage.getItem("accessToken");
 }
 
+async function refreshAccessToken(): Promise<boolean> {
+  try {
+    const res = await fetch(`${BASE_URL}/api/auth/token`, {
+      method: "POST",
+      credentials: "include",
+    });
+    if (!res.ok) return false;
+    const data = await res.json();
+    if (data.accessToken) localStorage.setItem("accessToken", data.accessToken);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 /**
  * 공통 API 요청 함수
  * 모든 fetch 요청의 기본 래퍼로 사용
  */
-export async function fetcher<T>(
+async function fetchWithAuth<T>(
   path: string,
-  options: RequestInit = {}
+  options: RequestInit,
+  retry = true
 ): Promise<T> {
   const token = getAccessToken();
 
@@ -36,9 +52,23 @@ export async function fetcher<T>(
     credentials: "include",
   });
 
+  if (res.status === 401 && retry) {
+    const refreshed = await refreshAccessToken();
+    if (refreshed) return fetchWithAuth<T>(path, options, false);
+    if (typeof window !== "undefined") window.location.href = "/login";
+    throw new Error("Unauthorized");
+  }
+
   if (!res.ok) {
     throw Error();
   }
 
   return res.json();
+}
+
+export async function fetcher<T>(
+  path: string,
+  options: RequestInit = {}
+): Promise<T> {
+  return fetchWithAuth<T>(path, options);
 }

--- a/src/lib/api/common.ts
+++ b/src/lib/api/common.ts
@@ -12,7 +12,7 @@ export function getAccessToken() {
 
 async function refreshAccessToken(): Promise<boolean> {
   try {
-    const res = await fetch(`${BASE_URL}/api/auth/token`, {
+    const res = await fetch(`${BASE_URL}/auth/token`, {
       method: "POST",
       credentials: "include",
     });

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+export function proxy(request: NextRequest) {
+  if (!request.cookies.has("onboarding")) {
+    return NextResponse.redirect(new URL("/onboarding", request.url));
+  }
+}
+
+export const config = {
+  matcher: ["/"],
+};

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,12 +1,27 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 
+const PUBLIC_PATHS = ["/login", "/onboarding", "/auth/success"];
+
 export function proxy(request: NextRequest) {
-  if (!request.cookies.has("onboarding")) {
-    return NextResponse.redirect(new URL("/onboarding", request.url));
+  const { pathname } = request.nextUrl;
+
+  const isPublic =
+    PUBLIC_PATHS.some((p) => pathname.startsWith(p)) ||
+    /^\/album\/[^/]+$/.test(pathname);
+
+  if (pathname === "/") {
+    if (!request.cookies.has("onboarding")) {
+      return NextResponse.redirect(new URL("/onboarding", request.url));
+    }
+    return;
+  }
+
+  if (!isPublic && !request.cookies.has("refreshToken")) {
+    return NextResponse.redirect(new URL("/login", request.url));
   }
 }
 
 export const config = {
-  matcher: ["/"],
+  matcher: ["/((?!_next/static|_next/image|favicon.ico|.*\\..*).*)"],
 };

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -8,7 +8,7 @@ export function proxy(request: NextRequest) {
 
   const isPublic =
     PUBLIC_PATHS.some((p) => pathname.startsWith(p)) ||
-    /^\/album\/[^/]+$/.test(pathname);
+    /^\/album\/\d+$/.test(pathname);
 
   if (pathname === "/") {
     if (!request.cookies.has("onboarding")) {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex. #61 

<br />

## 📝 작업 내용

### 플래시 현상 수정
- 온보딩/인트로 툴팁 상태를 `localStorage` + `useEffect` → 쿠키 기반 SSR로 전환
- 홈 버튼 컴포넌트의 `useEffect` 제거, 서버에서 초기값 prop으로 전달

### Proxy 도입
- 온보딩 리다이렉트를 서버 컴포넌트에서 Next.js Proxy로 이전
- 비로그인 사용자 보호 라우트 접근 차단 (`/album`, `/report`, `/mypage` 등)
- `/album/[id]` (팬 공개 페이지), `/login`, `/onboarding`, `/auth/success`는 public 처리

### 토큰 만료 처리
- API 401 응답 시 `POST /api/auth/token`으로 accessToken 재발급 후 요청 자동 재시도
- 재발급 실패 시 `/login` 이동

### 버그 수정
- `/album/promote`가 public으로 처리되던 정규식 버그 수정
- 회원탈퇴 시 `onboarding` 쿠키 미삭제로 재온보딩 스킵되던 문제 수정
- mypage `BASE_URL` 하드코딩 → 환경변수 교체 및 중복 `/api` 경로 수정


<br />

## 💬 리뷰 요구사항 ( 선택 )

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 <br />
> ex. 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 경로 접근 제어를 위한 미들웨어가 추가되어 인증되지 않은 사용자는 적절한 페이지로 리다이렉트됩니다.
  * 토큰 갱신 로직이 개선되어 인증 오류 발생 시 자동으로 재시도합니다.

* **개선 사항**
  * 로컬 스토리지에서 쿠키 기반 상태 관리로 전환되었습니다.
  * API 엔드포인트 구조가 최적화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->