### PR TITLE
#84 feat: 3.1.1~ 3.1.2 홍보운영점검 화면 기능 & 퍼블리싱

### DIFF
--- a/src/app/(default)/report/complete/page.tsx
+++ b/src/app/(default)/report/complete/page.tsx
@@ -1,0 +1,55 @@
+import { Button } from "@/components/ui/button";
+import Image from "next/image";
+import Link from "next/link";
+
+export default function Complete() {
+  return (
+    <main className="flex h-fit flex-col justify-between gap-16">
+      <div className="mt-7 flex flex-col gap-1">
+        <h4 className="h3-bold text-font-basic">진단 신청 완료!</h4>
+        <p className="p2-regular text-font-middle">
+          평균 1~2일 이내 결과를 확인하실 수 있어요
+          <br />
+          메일로 알려드릴게요
+        </p>
+      </div>
+
+      <section className="flex flex-col gap-2">
+        <p className="c1-bold text-main mt-3">Tip! 이렇게 해보세요</p>
+        <ul className="flex flex-col gap-2">
+          <li className="bg-grey1 grid grid-cols-[auto_1fr] items-center gap-5 rounded-2xl px-5 py-5">
+            <div className="num bg-font-middle c1-bold flex h-6 w-6 items-center justify-center rounded-full text-white">
+              1
+            </div>
+            <div className="text-wrap">
+              <p className="p2-regular text-font-middle">
+                진단은 발매일+1일/+3일/+5일 텀으로
+                <br />
+                홍보를 진행하면서 확인하면 좋아요
+              </p>
+            </div>
+          </li>
+
+          <li className="bg-grey1 grid grid-cols-[auto_1fr] items-center gap-5 rounded-2xl px-5 py-5">
+            <div className="num bg-font-middle c1-bold flex h-6 w-6 items-center justify-center rounded-full text-white">
+              2
+            </div>
+            <div className="text-wrap">
+              <p className="p2-regular text-font-middle">
+                이전 진단에서 발견한 취약부분을 개선에
+                <br />
+                반영했다면 훨씬 효과적인 홍보가 될 거예요
+              </p>
+            </div>
+          </li>
+        </ul>
+      </section>
+
+      <div className="fixed right-1/2 bottom-15 flex w-full max-w-(--max-width) translate-x-1/2 justify-center px-5">
+        <Button variant="btnPurple" size="full" asChild>
+          <Link href={"/"}>이전 진단 내역 보기</Link>
+        </Button>
+      </div>
+    </main>
+  );
+}

--- a/src/app/(default)/report/complete/page.tsx
+++ b/src/app/(default)/report/complete/page.tsx
@@ -1,5 +1,4 @@
 import { Button } from "@/components/ui/button";
-import Image from "next/image";
 import Link from "next/link";
 
 export default function Complete() {

--- a/src/app/(default)/report/page.tsx
+++ b/src/app/(default)/report/page.tsx
@@ -53,8 +53,10 @@ export default function Report() {
     const val = e.target.value;
     const next = val.startsWith("@") ? val : "@" + val.replace(/^@*/, "");
     setInstagram(next);
-    if (isValidInstagram(next)) {
+    if (next === "@") {
       setErrors((prev) => ({ ...prev, instagram: false }));
+    } else {
+      setErrors((prev) => ({ ...prev, instagram: !isValidInstagram(next) }));
     }
   };
 
@@ -104,8 +106,8 @@ export default function Report() {
   if (isPromotionsError) {
     return (
       <ErrorView
-        title={`앨범 목록을\n불러오지 못했어요`}
-        description={`잠시 후 다시 시도해주세요.`}
+        title={`요청하신 화면을\n불러오지 못했어요`}
+        description={`페이지가 없거나 연결이 잠시 불안정해요.\n잠시 후 다시 시도해주세요.`}
         onAction={refetch}
         actionLabel="다시 시도하기"
       />
@@ -114,6 +116,11 @@ export default function Report() {
 
   return (
     <main className="flex flex-col">
+      {isLoading && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-white/80">
+          <Spinner className="text-main" />
+        </div>
+      )}
       <div className="my-7 flex flex-col gap-1">
         <h4 className="h3-bold text-font-basic">
           홍보가 잘 되고 있는지 확인해봐요

--- a/src/app/(default)/report/page.tsx
+++ b/src/app/(default)/report/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 // import ComingSoon from "@/components/report/coming-soon";
-
 import { Input } from "@/components/common/input";
 import {
   Select,
@@ -13,7 +12,6 @@ import {
 } from "@/components/ui/select";
 import { Dialog, DialogContent, DialogTrigger } from "@/components/ui/dialog";
 import { Calendar } from "@/components/ui/calendar";
-import Image from "next/image";
 import Link from "next/link";
 import { CalendarIcon } from "lucide-react";
 import { useState } from "react";
@@ -39,7 +37,7 @@ export default function Report() {
       </div>
 
       <div className="flex flex-col gap-20">
-        <button className="text-font-middle bg-allwhite rounded-r2 shadow-btn flex h-15 cursor-pointer items-center gap-4 p-3">
+        {/* <button className="text-font-middle bg-allwhite rounded-r2 shadow-btn flex h-15 cursor-pointer items-center gap-4 p-3">
           <Image src="/insta.svg" alt="인스타그램" width={24} height={24} />
           <div className="flex flex-col items-start">
             <h6 className="p2-bold">인스타그램 계정 연동하기</h6>
@@ -47,7 +45,7 @@ export default function Report() {
               프로페셔널 계정만 연동 가능해요
             </p>
           </div>
-        </button>
+        </button> */}
         {/* <button className="text-font-middle bg-allwhite rounded-r2 shadow-btn flex h-15 items-center gap-4 p-3">
           <Image
             src="/peak-round-sm.svg"
@@ -91,6 +89,23 @@ export default function Report() {
             >
               새 홍보 링크 만들기
             </Link>
+          </div>
+        </section>
+
+        <section className="flex flex-col gap-3">
+          <div className="flex flex-col gap-1">
+            <h5 className="p1-bold text-font-middle">계정을 입력해주세요</h5>
+            <p className="p2-medium text-font-light">
+              홍보 중이신 인스타그램 계정을 입력해주세요
+            </p>
+            <Input
+              // className={
+              //   errors.artist ? "border-danger focus-visible:ring-danger" : ""
+              // }
+              label="인스타그램 계정"
+              placeholder="인스타그램 계정을 입력해주세요"
+              maxLength={50}
+            />
           </div>
         </section>
 
@@ -149,10 +164,9 @@ export default function Report() {
           />
         </section>
         {/* <Button variant="btnPurple" size="full" disabled={!date}>
-          진단 시작하기
-        </Button> */}
+         */}
         <Button variant="btnPurple" size="full">
-          진단 시작하기
+          <Link href="/report/complete">분석시작하기</Link>
         </Button>
       </div>
       {/* <ComingSoon /> */}

--- a/src/app/(default)/report/page.tsx
+++ b/src/app/(default)/report/page.tsx
@@ -172,8 +172,9 @@ export default function Report() {
           >
             <SelectTrigger
               className={errors.promotionId ? "border-danger" : ""}
+              disabled={promotions.length === 0}
             >
-              <SelectValue placeholder="앨범 선택하기" />
+              <SelectValue placeholder={promotions.length === 0 ? "생성된 홍보 링크가 없어요" : "앨범 선택하기"} />
             </SelectTrigger>
             <SelectContent position="popper">
               <SelectGroup>

--- a/src/app/(default)/report/page.tsx
+++ b/src/app/(default)/report/page.tsx
@@ -24,6 +24,8 @@ import {
 } from "@/lib/api/music-promotion";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
+import { Spinner } from "@/components/ui/spinner";
+import ErrorView from "@/components/common/error-view";
 
 type ReportFormErrors = {
   promotionId: boolean;
@@ -56,7 +58,12 @@ export default function Report() {
     }
   };
 
-  const { data: promotionsData } = useQuery({
+  const {
+    data: promotionsData,
+    isLoading: isPromotionsLoading,
+    isError: isPromotionsError,
+    refetch,
+  } = useQuery({
     queryKey: ["myPagePromotions"],
     queryFn: getMyPagePromotions,
   });
@@ -85,6 +92,25 @@ export default function Report() {
       setIsLoading(false);
     }
   };
+
+  if (isPromotionsLoading) {
+    return (
+      <div className="flex flex-1 items-center justify-center">
+        <Spinner className="text-main" />
+      </div>
+    );
+  }
+
+  if (isPromotionsError) {
+    return (
+      <ErrorView
+        title={`앨범 목록을\n불러오지 못했어요`}
+        description={`잠시 후 다시 시도해주세요.`}
+        onAction={refetch}
+        actionLabel="다시 시도하기"
+      />
+    );
+  }
 
   return (
     <main className="flex flex-col">
@@ -179,7 +205,7 @@ export default function Report() {
               }
               label="인스타그램 계정"
               placeholder="인스타그램 계정을 입력해주세요"
-              maxLength={50}
+              maxLength={31}
               value={instagram}
               onChange={handleInstagramChange}
             />

--- a/src/app/(default)/report/page.tsx
+++ b/src/app/(default)/report/page.tsx
@@ -17,11 +17,55 @@ import { CalendarIcon } from "lucide-react";
 import { useState } from "react";
 import { format } from "date-fns";
 import { Button } from "@/components/ui/button";
+import { useQuery } from "@tanstack/react-query";
+import { getMyPagePromotions } from "@/lib/api/music-promotion";
+import { useRouter } from "next/navigation";
+
+type ReportFormErrors = {
+  promotionId: boolean;
+  instagram: boolean;
+  date: boolean;
+};
 
 export default function Report() {
+  const router = useRouter();
   const [date, setDate] = useState<Date | undefined>();
   const [calendarOpen, setCalendarOpen] = useState(false);
-  const [errors] = useState({ date: false });
+  const [selectedPromotionId, setSelectedPromotionId] = useState<string>("");
+  const [instagram, setInstagram] = useState("@");
+  const [errors, setErrors] = useState<ReportFormErrors>({
+    promotionId: false,
+    instagram: false,
+    date: false,
+  });
+
+  const handleInstagramChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const val = e.target.value;
+    const next = val.startsWith("@") ? val : "@" + val.replace(/^@*/, "");
+    setInstagram(next);
+    if (next.trim().length > 1) {
+      setErrors((prev) => ({ ...prev, instagram: false }));
+    }
+  };
+
+  const { data: promotionsData } = useQuery({
+    queryKey: ["myPagePromotions"],
+    queryFn: getMyPagePromotions,
+  });
+  const promotions = promotionsData?.promotions ?? [];
+
+  const handleSubmit = () => {
+    const newErrors: ReportFormErrors = {
+      promotionId: !selectedPromotionId,
+      instagram: instagram.trim().length <= 1,
+      date: !date,
+    };
+    setErrors(newErrors);
+
+    if (newErrors.promotionId || newErrors.instagram || newErrors.date) return;
+
+    router.push("/report/complete");
+  };
 
   return (
     <main className="flex flex-col">
@@ -67,15 +111,25 @@ export default function Report() {
               생성된 홍보 링크 기준으로 분석해드려요
             </p>
           </div>
-          <Select>
-            <SelectTrigger>
+          <Select
+            value={selectedPromotionId}
+            onValueChange={(v) => {
+              setSelectedPromotionId(v);
+              setErrors((prev) => ({ ...prev, promotionId: false }));
+            }}
+          >
+            <SelectTrigger
+              className={errors.promotionId ? "border-danger" : ""}
+            >
               <SelectValue placeholder="앨범 선택하기" />
             </SelectTrigger>
             <SelectContent position="popper">
               <SelectGroup>
-                <SelectItem value="앨범명 1">앨범명 1</SelectItem>
-                <SelectItem value="앨범명 2">앨범명 2</SelectItem>
-                <SelectItem value="앨범명 3">앨범명 3</SelectItem>
+                {promotions.map((p) => (
+                  <SelectItem key={p.promotionId} value={String(p.promotionId)}>
+                    {p.title}
+                  </SelectItem>
+                ))}
               </SelectGroup>
             </SelectContent>
           </Select>
@@ -99,12 +153,16 @@ export default function Report() {
               홍보 중이신 인스타그램 계정을 입력해주세요
             </p>
             <Input
-              // className={
-              //   errors.artist ? "border-danger focus-visible:ring-danger" : ""
-              // }
+              className={
+                errors.instagram
+                  ? "border-danger focus-visible:ring-danger"
+                  : ""
+              }
               label="인스타그램 계정"
               placeholder="인스타그램 계정을 입력해주세요"
               maxLength={50}
+              value={instagram}
+              onChange={handleInstagramChange}
             />
           </div>
         </section>
@@ -147,6 +205,7 @@ export default function Report() {
                     onSelect={(d) => {
                       setDate(d);
                       setCalendarOpen(false);
+                      setErrors((prev) => ({ ...prev, date: false }));
                     }}
                     className="flex w-full"
                     classNames={{
@@ -163,10 +222,16 @@ export default function Report() {
             }
           />
         </section>
-        {/* <Button variant="btnPurple" size="full" disabled={!date}>
-         */}
-        <Button variant="btnPurple" size="full">
-          <Link href="/report/complete">분석시작하기</Link>
+
+        <Button
+          variant="btnPurple"
+          size="full"
+          disabled={
+            !selectedPromotionId || instagram.trim().length <= 1 || !date
+          }
+          onClick={handleSubmit}
+        >
+          분석 시작하기
         </Button>
       </div>
       {/* <ComingSoon /> */}

--- a/src/app/(default)/report/page.tsx
+++ b/src/app/(default)/report/page.tsx
@@ -44,11 +44,14 @@ export default function Report() {
   });
   const [isLoading, setIsLoading] = useState(false);
 
+  const isValidInstagram = (value: string) =>
+    /^@[a-zA-Z0-9._]{1,30}$/.test(value);
+
   const handleInstagramChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const val = e.target.value;
     const next = val.startsWith("@") ? val : "@" + val.replace(/^@*/, "");
     setInstagram(next);
-    if (next.trim().length > 1) {
+    if (isValidInstagram(next)) {
       setErrors((prev) => ({ ...prev, instagram: false }));
     }
   };
@@ -62,7 +65,7 @@ export default function Report() {
   const handleSubmit = async () => {
     const newErrors: ReportFormErrors = {
       promotionId: !selectedPromotionId,
-      instagram: instagram.trim().length <= 1,
+      instagram: !isValidInstagram(instagram),
       date: !date,
     };
     setErrors(newErrors);
@@ -218,6 +221,13 @@ export default function Report() {
                   <Calendar
                     mode="single"
                     selected={date}
+                    disabled={(d) => {
+                      const today = new Date();
+                      today.setHours(0, 0, 0, 0);
+                      const oneYearAgo = new Date(today);
+                      oneYearAgo.setFullYear(today.getFullYear() - 1);
+                      return d > today || d < oneYearAgo;
+                    }}
                     onSelect={(d) => {
                       setDate(d);
                       setCalendarOpen(false);
@@ -243,7 +253,7 @@ export default function Report() {
           variant="btnPurple"
           size="full"
           disabled={
-            !selectedPromotionId || instagram.trim().length <= 1 || !date || isLoading
+            !selectedPromotionId || !isValidInstagram(instagram) || !date || isLoading
           }
           onClick={handleSubmit}
         >

--- a/src/app/(default)/report/page.tsx
+++ b/src/app/(default)/report/page.tsx
@@ -18,8 +18,12 @@ import { useState } from "react";
 import { format } from "date-fns";
 import { Button } from "@/components/ui/button";
 import { useQuery } from "@tanstack/react-query";
-import { getMyPagePromotions } from "@/lib/api/music-promotion";
+import {
+  analyzePromotion,
+  getMyPagePromotions,
+} from "@/lib/api/music-promotion";
 import { useRouter } from "next/navigation";
+import { toast } from "sonner";
 
 type ReportFormErrors = {
   promotionId: boolean;
@@ -38,6 +42,7 @@ export default function Report() {
     instagram: false,
     date: false,
   });
+  const [isLoading, setIsLoading] = useState(false);
 
   const handleInstagramChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const val = e.target.value;
@@ -54,7 +59,7 @@ export default function Report() {
   });
   const promotions = promotionsData?.promotions ?? [];
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     const newErrors: ReportFormErrors = {
       promotionId: !selectedPromotionId,
       instagram: instagram.trim().length <= 1,
@@ -64,7 +69,18 @@ export default function Report() {
 
     if (newErrors.promotionId || newErrors.instagram || newErrors.date) return;
 
-    router.push("/report/complete");
+    setIsLoading(true);
+    try {
+      await analyzePromotion(Number(selectedPromotionId), {
+        sinceDate: format(date!, "yyyy-MM-dd"),
+        instagramAccountId: instagram.replace("@", ""),
+      });
+      router.push("/report/complete");
+    } catch {
+      toast.error("분석 요청에 실패했어요. 잠시 후 다시 시도해주세요.");
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   return (
@@ -227,7 +243,7 @@ export default function Report() {
           variant="btnPurple"
           size="full"
           disabled={
-            !selectedPromotionId || instagram.trim().length <= 1 || !date
+            !selectedPromotionId || instagram.trim().length <= 1 || !date || isLoading
           }
           onClick={handleSubmit}
         >

--- a/src/lib/api/music-promotion.ts
+++ b/src/lib/api/music-promotion.ts
@@ -1,6 +1,7 @@
 import { fetcher } from "@/lib/api/common";
 import { MusicPromotionInfo } from "@/types/album";
 import {
+  AnalyzeRes,
   CreateMusicPromotionRes,
   GetMusicPromotionRes,
   GetMyPagePromotionsRes,
@@ -84,6 +85,25 @@ export async function getMusicPromotion(
  * 뮤지션 홍보 수정
  * [PUT] /music-promotions/{promotionId}
  */
+/**
+ * AI 분석 요청
+ * [POST] /ai/analyze/{promotionId}
+ */
+export async function analyzePromotion(
+  promotionId: number,
+  payload: { sinceDate: string; instagramAccountId: string }
+): Promise<AnalyzeRes> {
+  try {
+    const res = await fetcher<AnalyzeRes>(`/ai/analyze/${promotionId}`, {
+      method: "POST",
+      body: JSON.stringify(payload),
+    });
+    return res;
+  } catch {
+    throw new Error("[music-promotion]: AI 분석 요청 실패");
+  }
+}
+
 export async function updateMusicPromotion(
   promotionId: number,
   payload: MusicPromotionInfo

--- a/src/types/api-response.ts
+++ b/src/types/api-response.ts
@@ -37,6 +37,47 @@ export interface GetMyPagePromotionsRes {
   hasNext: boolean;
 }
 
+/******************************
+ * AI Analyze
+ ******************************/
+
+export interface AnalyzeRes {
+  headline: string;
+  diagnosis: {
+    bottleneckType: string;
+    highlightSection: string;
+    shareCount: number;
+    profileVisitCount: number;
+    linkClickCount: number;
+    interpretation: string;
+  };
+  calculatedMetrics: {
+    avgReachPerPost: number;
+    avgSharePerPost: number;
+    avgProfileVisitPerPost: number;
+    shareRateByReach: number;
+    profileVisitRateByReach: number;
+    linkClickRateByProfileVisit: number;
+    linkClickRateByReach: number;
+  };
+  channelInsight: {
+    bestChannel: string;
+    bestChannelClickRate: number;
+    summary: string;
+  };
+  postInsight: {
+    topPostPattern: string;
+    lowPostPattern: string;
+    suggestion: string;
+  };
+  actions: {
+    title: string;
+    reason: string;
+    metric: string;
+    example: string;
+  }[];
+}
+
 // 뮤지션 홍보 조회 Res
 export interface GetMusicPromotionRes {
   promotionId: number;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex. #84 

<br />

## 📝 작업 내용

- 홍보 운영 점검 입력 페이지 퍼블리싱
- 앨범 Select API 연동 및 폼 유효성 검사 추가
- AI 분석 요청 API 연동 (`POST /ai/analyze/{promotionId}`)
- 인스타그램 계정 유효성 검사 추가 (영문·숫자·`.`·`_`만 허용, 최대 30자, 한글·공백 차단)
- 날짜 선택 범위 제한 (오늘 이전 ~ 1년 이내)
- 앨범 목록 조회 실패 시 ErrorView + 재시도 처리
- 메일은 백엔드에서 일괄처리

<br />

## 💬 리뷰 요구사항 ( 선택 )

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 <br />
> ex. 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * AI 진단 분석 기능 추가 (프로모션 데이터 분석 및 결과 제공)
  * 인스타그램 계정 입력 필드 추가 (형식 검증)
  * 진단 신청 완료 페이지 추가
  * 날짜 범위 선택 기능 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->