### PR TITLE
#91 refactor: report 준비중페이지 라우트 분리

### DIFF
--- a/src/app/(default)/album/promote/page.tsx
+++ b/src/app/(default)/album/promote/page.tsx
@@ -64,7 +64,7 @@ export default function Promote() {
             이미 게시물을 올렸다면?
           </p>
           <Link
-            href={"/report"}
+            href={"/report/coming-soon"}
             className="text-main cursor-pointer text-xs font-bold underline"
           >
             내 홍보 콘텐츠 진단하기

--- a/src/app/(default)/report/coming-soon/page.tsx
+++ b/src/app/(default)/report/coming-soon/page.tsx
@@ -1,0 +1,5 @@
+import ComingSoon from "@/components/report/coming-soon";
+
+export default function ComingSoonPage() {
+  return <ComingSoon />;
+}

--- a/src/app/(default)/report/page.tsx
+++ b/src/app/(default)/report/page.tsx
@@ -1,5 +1,5 @@
-import ComingSoon from "@/components/report/coming-soon";
+import ReportForm from "@/components/report/report-form";
 
 export default function Report() {
-  return <ComingSoon />;
+  return <ReportForm />;
 }

--- a/src/components/home/home-buttons.tsx
+++ b/src/components/home/home-buttons.tsx
@@ -50,7 +50,7 @@ export default function HomeButtons({ showIntro }: { showIntro: boolean }) {
             <Button
               variant="btnWhite"
               size="full"
-              onClick={() => router.push("/report")}
+              onClick={() => router.push("/report/coming-soon")}
             >
               내 음원 홍보 진단하기
             </Button>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex. #91

<br />

## 📝 작업 내용

- `/report/coming-soon` 라우트 신규 추가 — 커밍순 화면 별도 배포
- `/report` 페이지를 `ReportForm` 컴포넌트로 교체 — 폼 기능 화면과 커밍순 화면 분리
- 홈 버튼 및 앨범 홍보 페이지의 `/report` 링크를 `/report/coming-soon`으로 수정


<br />

## 💬 리뷰 요구사항 ( 선택 )

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 <br />
> ex. 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 보고서 관련 페이지 네비게이션 경로 업데이트 및 구조 개선
  * 보고서 페이지에서 폼 기능 활성화
  * 준비 중인 페이지 추가로 단계적 기능 출시 준비

<!-- end of auto-generated comment: release notes by coderabbit.ai -->