### PR TITLE
#85 feat: 진단결과화면 이미지저장 기능작업

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "embla-carousel-auto-height": "^8.6.0",
         "embla-carousel-autoplay": "^8.6.0",
         "embla-carousel-react": "^8.6.0",
+        "html-to-image": "^1.11.13",
         "lucide-react": "^1.8.0",
         "next": "16.2.3",
         "next-themes": "^0.4.6",
@@ -7146,6 +7147,12 @@
       "engines": {
         "node": ">=16.9.0"
       }
+    },
+    "node_modules/html-to-image": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
+      "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
+      "license": "MIT"
     },
     "node_modules/http-errors": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "embla-carousel-auto-height": "^8.6.0",
     "embla-carousel-autoplay": "^8.6.0",
     "embla-carousel-react": "^8.6.0",
+    "html-to-image": "^1.11.13",
     "lucide-react": "^1.8.0",
     "next": "16.2.3",
     "next-themes": "^0.4.6",

--- a/src/app/(default)/report/[id]/page.tsx
+++ b/src/app/(default)/report/[id]/page.tsx
@@ -1,31 +1,11 @@
 import { Button } from "@/components/ui/button";
 import { Calendar, ChevronRight } from "lucide-react";
 import Link from "next/link";
-import type { ReactNode } from "react";
 
 const STATS = [
   { label: "게시글 공유수", value: 13 },
   { label: "프로필 방문자수", value: 6 },
   { label: "링크 클릭수", value: 0 },
-];
-
-const TIPS: { title: string; description: ReactNode[] }[] = [
-  {
-    title: "게시글 끝에 링크 유도 문구 넣기",
-    description: [
-      '"프로필 링크에서 바로 들어보세요"\n한 줄만 추가해도 클릭률이 달라져요',
-    ],
-  },
-  {
-    title: "프로필 링크 문구를 신곡 제목으로 바꾸기",
-    description: [
-      "링크 이름을 “신곡 제목 듣기”처럼\n눌러보고 싶은 문구로 바꿔보세요",
-    ],
-  },
-  {
-    title: "짧고 강한 후킹 게시물 2개 올리기",
-    description: ["공유되기 쉬운 릴스나 이미지로\n반응하기 쉽게 만들어보세요"],
-  },
 ];
 
 export default function ReportDetailPage() {
@@ -75,20 +55,14 @@ export default function ReportDetailPage() {
       <section className="flex flex-col gap-2">
         <h5 className="h3-bold">이렇게 해보세요</h5>
         <ul className="flex flex-col gap-2">
-          {TIPS.map(({ title, description }, index) => (
-            <li
-              key={index}
-              className="bg-grey1 grid grid-cols-[auto_1fr] items-center gap-5 rounded-2xl px-5 py-5"
-            >
-              <div className="num bg-font-light c1-bold flex h-6 w-6 items-center justify-center rounded-full text-white">
-                {index + 1}
-              </div>
-              <div className="flex flex-col gap-1 text-wrap break-keep whitespace-pre-line">
-                <h5 className="p1-bold text-main">{title}</h5>
-                <p className="p2-regular text-font-middle">{description}</p>
-              </div>
-            </li>
-          ))}
+          <li className="bg-grey1 grid grid-cols-[1fr] items-center gap-5 rounded-2xl px-5 py-5">
+            <div className="flex flex-col gap-1 text-wrap break-keep whitespace-pre-line">
+              <h5 className="p1-bold text-main">게시글 끝에 링크 유도 문구 넣기</h5>
+              <p className="p2-regular text-font-middle">
+                {'"프로필 링크에서 바로 들어보세요"\n한 줄만 추가해도 클릭률이 달라져요'}
+              </p>
+            </div>
+          </li>
         </ul>
       </section>
 

--- a/src/app/(default)/report/[id]/page.tsx
+++ b/src/app/(default)/report/[id]/page.tsx
@@ -18,7 +18,7 @@ export default function ReportDetailPage() {
     try {
       const dataUrl = await toJpeg(target, {
         cacheBust: true,
-        pixelRatio: 1,
+        pixelRatio: 2,
         filter: (node: HTMLElement) => !node.dataset?.captureIgnore,
       });
       const link = document.createElement("a");
@@ -33,7 +33,7 @@ export default function ReportDetailPage() {
   return (
     <main className="flex flex-col gap-9">
       <div
-        className="bg-allwhite flex min-h-screen flex-col gap-9"
+        className="bg-allwhite flex min-h-screen flex-col gap-9 pb-24"
       >
         <div className="mt-7 flex flex-col items-start gap-1">
           <h2 className="h2-bold text-font-basic">

--- a/src/app/(default)/report/[id]/page.tsx
+++ b/src/app/(default)/report/[id]/page.tsx
@@ -3,7 +3,7 @@
 import { Button } from "@/components/ui/button";
 import { Calendar, ChevronRight } from "lucide-react";
 import { useRef } from "react";
-import { toPng } from "html-to-image";
+import { toJpeg } from "html-to-image";
 import { toast } from "sonner";
 
 const STATS = [
@@ -19,13 +19,13 @@ export default function ReportDetailPage() {
     const target = captureRef.current;
     if (!target) return;
     try {
-      const dataUrl = await toPng(target, {
+      const dataUrl = await toJpeg(target, {
         cacheBust: true,
         pixelRatio: 1,
-        filter: (node) => !node.dataset?.captureIgnore,
+        filter: (node: HTMLElement) => !node.dataset?.captureIgnore,
       });
       const link = document.createElement("a");
-      link.download = "report.png";
+      link.download = "report.jpg";
       link.href = dataUrl;
       link.click();
     } catch {
@@ -34,8 +34,11 @@ export default function ReportDetailPage() {
   };
 
   return (
-    <main className="bg-allwhite flex flex-col gap-9">
-      <div ref={captureRef} className="flex min-h-screen flex-col gap-9">
+    <main className="flex flex-col gap-9">
+      <div
+        ref={captureRef}
+        className="bg-allwhite flex min-h-screen flex-col gap-9"
+      >
         <div className="mt-7 flex flex-col items-start gap-1">
           <h2 className="h2-bold text-font-basic">
             김피크님의 홍보 현황이에요

--- a/src/app/(default)/report/[id]/page.tsx
+++ b/src/app/(default)/report/[id]/page.tsx
@@ -2,7 +2,6 @@
 
 import { Button } from "@/components/ui/button";
 import { Calendar, ChevronRight } from "lucide-react";
-import { useRef } from "react";
 import { toJpeg } from "html-to-image";
 import { toast } from "sonner";
 
@@ -13,10 +12,8 @@ const STATS = [
 ];
 
 export default function ReportDetailPage() {
-  const captureRef = useRef<HTMLDivElement>(null);
-
   const handleSaveImage = async () => {
-    const target = captureRef.current;
+    const target = document.getElementById("app-root");
     if (!target) return;
     try {
       const dataUrl = await toJpeg(target, {
@@ -36,7 +33,6 @@ export default function ReportDetailPage() {
   return (
     <main className="flex flex-col gap-9">
       <div
-        ref={captureRef}
         className="bg-allwhite flex min-h-screen flex-col gap-9"
       >
         <div className="mt-7 flex flex-col items-start gap-1">

--- a/src/app/(default)/report/[id]/page.tsx
+++ b/src/app/(default)/report/[id]/page.tsx
@@ -1,6 +1,10 @@
+"use client";
+
 import { Button } from "@/components/ui/button";
 import { Calendar, ChevronRight } from "lucide-react";
-import Link from "next/link";
+import { useRef } from "react";
+import { toPng } from "html-to-image";
+import { toast } from "sonner";
 
 const STATS = [
   { label: "게시글 공유수", value: 13 },
@@ -9,66 +13,97 @@ const STATS = [
 ];
 
 export default function ReportDetailPage() {
+  const captureRef = useRef<HTMLDivElement>(null);
+
+  const handleSaveImage = async () => {
+    const target = captureRef.current;
+    if (!target) return;
+    try {
+      const dataUrl = await toPng(target, {
+        cacheBust: true,
+        pixelRatio: 1,
+        filter: (node) => !node.dataset?.captureIgnore,
+      });
+      const link = document.createElement("a");
+      link.download = "report.png";
+      link.href = dataUrl;
+      link.click();
+    } catch {
+      toast.error("이미지 저장에 실패했어요. 잠시 후 다시 시도해주세요.");
+    }
+  };
+
   return (
-    <main className="flex flex-col gap-9">
-      <div className="mt-7 flex flex-col items-start gap-1">
-        <h2 className="h2-bold text-font-basic">김피크님의 홍보 현황이에요</h2>
-        <div className="border-border text-font-middle flex items-center gap-2 rounded-full border px-4 py-2">
-          <Calendar size={16} />
-          <span className="p2-medium">26.04.01 - 26.04.14</span>
-        </div>
-      </div>
-
-      <div className="flex flex-col gap-4">
-        <section className="grid grid-cols-3 gap-5 text-center">
-          {STATS.map(({ label, value }) => (
-            <div
-              key={label}
-              className="box-item rounded-r2 bg-grey1 flex min-h-26 flex-col justify-start gap-2.5 p-2.5"
-            >
-              <div className="c1-medium text-font-middle rounded-r1 w-full bg-white py-1">
-                {label}
-              </div>
-              <h1 className="text-main text-4xl font-semibold">{value}</h1>
-            </div>
-          ))}
-        </section>
-
-        <section className="border-border rounded-r3 flex flex-col gap-4 border p-5">
-          <h6 className="text-font-middle p1-bold flex flex-col gap-1">
-            지금 홍보가 막힌 단계는
-            <span className="text-main-dark1 h3-bold flex items-center gap-1">
-              피드 게시글
-              <ChevronRight size={24} />
-              프로필 방문
-            </span>
-            이에요
-          </h6>
-          <div className="bg-brand-gradient rounded-r2 p-4 break-keep whitespace-pre-line text-white">
-            게시글 반응은 있지만, 프로필 링크까지 이어지지 않았어요.
-            <br />
-            <strong>콘텐츠에 링크로 유도하는 장치가 필요해요.</strong>
+    <main className="bg-allwhite flex flex-col gap-9">
+      <div ref={captureRef} className="flex min-h-screen flex-col gap-9">
+        <div className="mt-7 flex flex-col items-start gap-1">
+          <h2 className="h2-bold text-font-basic">
+            김피크님의 홍보 현황이에요
+          </h2>
+          <div className="border-border text-font-middle flex items-center gap-2 rounded-full border px-4 py-2">
+            <Calendar size={16} />
+            <span className="p2-medium">26.04.01 - 26.04.14</span>
           </div>
+        </div>
+
+        <div className="flex flex-col gap-4">
+          <section className="grid grid-cols-3 gap-5 text-center">
+            {STATS.map(({ label, value }) => (
+              <div
+                key={label}
+                className="box-item rounded-r2 bg-grey1 flex min-h-26 flex-col justify-start gap-2.5 p-2.5"
+              >
+                <div className="c1-medium text-font-middle rounded-r1 w-full bg-white py-1">
+                  {label}
+                </div>
+                <h1 className="text-main text-4xl font-semibold">{value}</h1>
+              </div>
+            ))}
+          </section>
+
+          <section className="border-border rounded-r3 flex flex-col gap-4 border p-5">
+            <h6 className="text-font-middle p1-bold flex flex-col gap-1">
+              지금 홍보가 막힌 단계는
+              <span className="text-main-dark1 h3-bold flex items-center gap-1">
+                피드 게시글
+                <ChevronRight size={24} />
+                프로필 방문
+              </span>
+              이에요
+            </h6>
+            <div className="bg-brand-gradient rounded-r2 p-4 break-keep whitespace-pre-line text-white">
+              게시글 반응은 있지만, 프로필 링크까지 이어지지 않았어요.
+              <br />
+              <strong>콘텐츠에 링크로 유도하는 장치가 필요해요.</strong>
+            </div>
+          </section>
+        </div>
+
+        <section className="flex flex-col gap-2">
+          <h5 className="h3-bold">이렇게 해보세요</h5>
+          <ul className="flex flex-col gap-2">
+            <li className="bg-grey1 grid grid-cols-[1fr] items-center gap-5 rounded-2xl px-5 py-5">
+              <div className="flex flex-col gap-1 text-wrap break-keep whitespace-pre-line">
+                <h5 className="p1-bold text-main">
+                  게시글 끝에 링크 유도 문구 넣기
+                </h5>
+                <p className="p2-regular text-font-middle">
+                  {
+                    '"프로필 링크에서 바로 들어보세요"\n한 줄만 추가해도 클릭률이 달라져요'
+                  }
+                </p>
+              </div>
+            </li>
+          </ul>
         </section>
       </div>
 
-      <section className="flex flex-col gap-2">
-        <h5 className="h3-bold">이렇게 해보세요</h5>
-        <ul className="flex flex-col gap-2">
-          <li className="bg-grey1 grid grid-cols-[1fr] items-center gap-5 rounded-2xl px-5 py-5">
-            <div className="flex flex-col gap-1 text-wrap break-keep whitespace-pre-line">
-              <h5 className="p1-bold text-main">게시글 끝에 링크 유도 문구 넣기</h5>
-              <p className="p2-regular text-font-middle">
-                {'"프로필 링크에서 바로 들어보세요"\n한 줄만 추가해도 클릭률이 달라져요'}
-              </p>
-            </div>
-          </li>
-        </ul>
-      </section>
-
-      <div className="flex flex-col gap-4 px-6">
-        <Button variant="btnPurple" size="full" asChild>
-          <Link href={"/"}>이미지 저장하기</Link>
+      <div
+        data-capture-ignore
+        className="fixed right-1/2 bottom-15 flex w-full max-w-(--max-width) translate-x-1/2 justify-center px-5"
+      >
+        <Button variant="btnPurple" size="full" onClick={handleSaveImage}>
+          이미지 저장하기
         </Button>
       </div>
     </main>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -80,8 +80,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             style={{ display: "none", visibility: "hidden" }}
           />
         </noscript>
-        <div className="mx-auto flex min-h-screen w-full max-w-(--max-width) flex-col pb-9 shadow-2xl">
-          <div id="app-root" className="flex flex-1 flex-col bg-white px-5">
+        <div className="mx-auto flex min-h-screen w-full max-w-(--max-width) flex-col shadow-2xl">
+          <div
+            id="app-root"
+            className="flex flex-1 flex-col bg-white px-5 pb-9"
+          >
             <QueryProvider>
               <TooltipProvider>{children}</TooltipProvider>
             </QueryProvider>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -80,8 +80,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             style={{ display: "none", visibility: "hidden" }}
           />
         </noscript>
-        <div className="mx-auto flex min-h-screen w-full max-w-(--max-width) flex-col bg-white px-5 pb-9 shadow-2xl">
-          <div className="flex flex-1 flex-col">
+        <div className="mx-auto flex min-h-screen w-full max-w-(--max-width) flex-col pb-9 shadow-2xl">
+          <div id="app-root" className="flex flex-1 flex-col bg-white px-5">
             <QueryProvider>
               <TooltipProvider>{children}</TooltipProvider>
             </QueryProvider>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex. #85

<br />

## 📝 작업 내용
<img width="750" height="1776" alt="report (2)" src="https://github.com/user-attachments/assets/918ad2f5-c04f-44b2-8023-69f99b5a8898" />

### 1. Report 결과 페이지 Tips 단일 표시 변경
- 기존 여러 항목 → 단일 항목으로 변경

### 2. 진단결과 이미지 저장 기능 추가
- `html-to-image` 라이브러리로 페이지 캡처 → JPG 다운로드
- 이미지 저장 버튼 고정(fixed) 배치

### 3. 저장 포맷 PNG → JPG 변경

### 4. 이미지 저장 시 헤더 포함 및 레이아웃 패딩 적용
- 루트 레이아웃에 `id="app-root"` 추가해 `getElementById`로 캡처 대상 지정
- 헤더까지 포함한 전체 영역 캡처
- `px-5`를 inner div로 이동해 캡처 이미지에 패딩 포함
- `bg-white` 추가로 투명 배경(검은 영역) 문제 해결

### 5. 이미지 해상도 및 버튼 레이아웃 개선
- `pixelRatio: 1 → 2`로 변경해 해상도 개선
- 콘텐츠에 `pb-24` 추가해 fixed 버튼에 가리는 문제 해결

<br />

## 💬 리뷰 요구사항 ( 선택 )

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 <br />
> ex. 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 보고서를 JPEG 이미지로 저장하고 다운로드할 수 있는 기능이 추가되었습니다.
  * 보고서 상세 페이지에서 버튼을 클릭하여 현재 화면을 이미지 파일로 캡처하고 저장할 수 있습니다.

* **Improvements**
  * 보고서 페이지의 팁 섹션 레이아웃이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->