### PR TITLE
#97 refactor: 로그인 상태체크 리팩토링

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# claude code
+/memory

--- a/src/app/(default)/auth/success/page.tsx
+++ b/src/app/(default)/auth/success/page.tsx
@@ -15,7 +15,12 @@ export default function AuthSuccess() {
       signal: controller.signal,
     })
       .then((res) => {
-        router.replace(res.ok ? "/" : "/login");
+        if (res.ok) {
+          document.cookie = "isLoggedIn=true; path=/; max-age=604800";
+          router.replace("/");
+        } else {
+          router.replace("/login");
+        }
       })
       .catch(() => router.replace("/login"))
       .finally(() => clearTimeout(timer));

--- a/src/app/(default)/mypage/page.tsx
+++ b/src/app/(default)/mypage/page.tsx
@@ -88,6 +88,8 @@ export default function MyPage() {
       method: "POST",
       credentials: "include",
     });
+    document.cookie = "isLoggedIn=; path=/; max-age=0";
+    localStorage.removeItem("accessToken");
     router.push("/");
     router.refresh();
   };
@@ -148,6 +150,8 @@ export default function MyPage() {
             return;
           }
           document.cookie = "onboarding=; path=/; max-age=0";
+          document.cookie = "isLoggedIn=; path=/; max-age=0";
+          localStorage.removeItem("accessToken");
           router.replace("/onboarding");
           router.refresh();
         } catch {

--- a/src/components/common/header.tsx
+++ b/src/components/common/header.tsx
@@ -5,7 +5,7 @@ import { cookies } from "next/headers";
 
 export default async function Header() {
   const cookieStore = await cookies();
-  const isLoggedIn = cookieStore.has("refreshToken");
+  const isLoggedIn = cookieStore.has("isLoggedIn");
 
   return (
     <div className="sticky top-0 z-40 flex h-14 w-full items-center justify-between bg-white">

--- a/src/lib/api/common.ts
+++ b/src/lib/api/common.ts
@@ -1,12 +1,7 @@
 const BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
 
-/**
- * 로컬 스토리지에서 저장된 JWT accessToken 조회
- * dev / prod 공통 사용
- */
 export function getAccessToken() {
   if (typeof window === "undefined") return null;
-
   return localStorage.getItem("accessToken");
 }
 

--- a/src/lib/api/dev.ts
+++ b/src/lib/api/dev.ts
@@ -14,6 +14,7 @@ export async function getDevToken(musicianId: number) {
     );
 
     localStorage.setItem("accessToken", accessToken);
+    document.cookie = "isLoggedIn=true; path=/; max-age=604800";
   } catch (e) {
     throw new Error("[dev]: 개발용 JWT 발급 실패");
   }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex. #97 

<br />

## 📝 작업 내용

## 개선 배경

헤더 컴포넌트가 로그인 여부를 `refreshToken` 쿠키로 체크하고 있었는데,
dev 환경에서는 OAuth 로그인이 프로덕션 도메인으로 리다이렉트되어 쿠키가 세팅되지 않는 문제가 있었음.
또한 dev 토큰(`/dev/token`)은 response body로 `accessToken`만 반환하고 쿠키를 세팅하지 않아
로컬에서 로그인 상태를 재현할 수 없었음.

## 인증 구조 파악

| 환경 | accessToken | refreshToken |
|---|---|---|
| 실제 OAuth 로그인 | httpOnly 쿠키 | httpOnly 쿠키 |
| dev 토큰 | response body → localStorage | 없음 |

- 헤더는 Server Component라 localStorage 접근 불가
- httpOnly 쿠키는 JS에서 직접 세팅 불가
- → dev/prod 환경 모두 동일하게 동작하는 별도 UI 상태 쿠키 필요

## 변경 사항

### `isLoggedIn` 쿠키 도입
- 인증용 토큰과 UI 상태 분리
- 헤더 로그인 체크를 `refreshToken` → `isLoggedIn` 쿠키로 변경

### 쿠키 세팅 시점
- OAuth 로그인 성공 시 (`auth/success`) — `/me` 확인 후 세팅
- dev 토큰 발급 시 (`dev.ts`) — 발급 성공 후 세팅

### 쿠키 제거 시점
- 로그아웃 시 `isLoggedIn` 쿠키 및 localStorage `accessToken` 정리
- 회원탈퇴 시 동일하게 정리

## 효과
- dev 환경에서도 로컬 로그인 테스트 가능
- SSR 헤더에서 환경(dev/prod) 상관없이 동일하게 로그인 상태 체크


<br />

## 💬 리뷰 요구사항 ( 선택 )

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 <br />
> ex. 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 로그인 및 로그아웃 프로세스의 세션 상태 관리가 개선되었습니다.
  * 인증 플로우 및 쿠키 처리가 더 명확하게 처리되도록 수정되었습니다.

* **Chores**
  * 개발 환경 설정 파일이 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->