### PR TITLE
#99 fix: 로그인 후 헤더 즉시 반영을 위해 window.location.replace로 변경

### DIFF
--- a/src/app/(default)/auth/success/page.tsx
+++ b/src/app/(default)/auth/success/page.tsx
@@ -1,11 +1,8 @@
 "use client";
 import { useEffect } from "react";
-import { useRouter } from "next/navigation";
 import { Spinner } from "@/components/ui/spinner";
 
 export default function AuthSuccess() {
-  const router = useRouter();
-
   useEffect(() => {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), 10_000);
@@ -17,19 +14,19 @@ export default function AuthSuccess() {
       .then((res) => {
         if (res.ok) {
           document.cookie = "isLoggedIn=true; path=/; max-age=604800";
-          router.replace("/");
+          window.location.replace("/");
         } else {
-          router.replace("/login");
+          window.location.replace("/login");
         }
       })
-      .catch(() => router.replace("/login"))
+      .catch(() => { window.location.replace("/login"); })
       .finally(() => clearTimeout(timer));
 
     return () => {
       clearTimeout(timer);
       controller.abort();
     };
-  }, [router]);
+  }, []);
 
   return (
     <div className="flex min-h-screen items-center justify-center">

--- a/src/app/(default)/auth/success/page.tsx
+++ b/src/app/(default)/auth/success/page.tsx
@@ -19,7 +19,7 @@ export default function AuthSuccess() {
           window.location.replace("/login");
         }
       })
-      .catch(() => { window.location.replace("/login"); })
+      .catch((err) => { if (err.name !== "AbortError") window.location.replace("/login"); })
       .finally(() => clearTimeout(timer));
 
     return () => {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex. #99

<br />

## 📝 작업 내용

### 문제
로그인 후 `router.replace("/")`로 이동 시 Next.js가 캐시된 RSC 데이터를 사용해서
헤더에 `isLoggedIn` 쿠키가 바로 반영 안 됨 (새로고침 해야 프로필 아이콘 노출)

### 변경
- `router.replace("/")` → `window.location.replace("/")`
- 성공/실패/catch 모두 `window.location.replace`로 통일
- `useRouter` import 제거

### 이유
- `window.location.replace`는 브라우저가 서버에 새 HTTP 요청을 보내서 쿠키를 확실히 읽음
- `auth/success`를 history에서 대체하기 때문에 뒤로가기로 돌아와서 `/me` 재호출되는 루프도 방지


<br />

## 💬 리뷰 요구사항 ( 선택 )

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 <br />
> ex. 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 인증 성공 페이지의 리다이렉션 동작을 개선했습니다. 인증 결과에 따라 홈 또는 로그인 페이지로 보다 안정적으로 이동하며, 기존 타임아웃 및 쿠키 처리 동작은 유지됩니다. 사용자 경험의 일관성과 복귀 흐름이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->