### PR TITLE
#107 design: 진단 완료 페이지 버튼 영역 수정

### DIFF
--- a/src/app/(default)/report/complete/page.tsx
+++ b/src/app/(default)/report/complete/page.tsx
@@ -55,7 +55,7 @@ export default function Complete() {
             </p>
             <Link
               href={"/"}
-              className="text-main cursor-pointer text-xs font-bold underline"
+              className="text-main c1-bold cursor-pointer underline"
             >
               이전 진단 내역 보기
             </Link>

--- a/src/app/(default)/report/complete/page.tsx
+++ b/src/app/(default)/report/complete/page.tsx
@@ -50,7 +50,7 @@ export default function Complete() {
             <Link href={"/mypage"}>마이페이지로 이동</Link>
           </Button>
           <div className="flex flex-col gap-1 text-center">
-            <p className="text-font-light c1-medium cursor-pointer">
+            <p className="text-font-light c1-medium">
               이미 진단받은 적이 있으신가요?
             </p>
             <Link

--- a/src/app/(default)/report/complete/page.tsx
+++ b/src/app/(default)/report/complete/page.tsx
@@ -45,9 +45,22 @@ export default function Complete() {
       </section>
 
       <div className="fixed right-1/2 bottom-15 flex w-full max-w-(--max-width) translate-x-1/2 justify-center px-5">
-        <Button variant="btnPurple" size="full" asChild>
-          <Link href={"/"}>이전 진단 내역 보기</Link>
-        </Button>
+        <div className="flex w-full flex-col gap-4 px-6">
+          <Button variant="btnPurple" size="full" asChild>
+            <Link href={"/mypage"}>마이페이지로 이동</Link>
+          </Button>
+          <div className="flex flex-col gap-1 text-center">
+            <p className="text-font-light c1-medium cursor-pointer">
+              이미 진단받은 적이 있으신가요?
+            </p>
+            <Link
+              href={"/"}
+              className="text-main cursor-pointer text-xs font-bold underline"
+            >
+              이전 진단 내역 보기
+            </Link>
+          </div>
+        </div>
       </div>
     </main>
   );


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex. #107

<br />

## 📝 작업 내용

## 변경 사항
<img width="644" height="193" alt="image" src="https://github.com/user-attachments/assets/c581b61d-375c-477d-b240-971ec4699097" />

진단 완료 페이지 하단 버튼 영역을 수정했습니다.

### 수정 내용
- 기존 "이전 진단 내역 보기" 단일 버튼 → "마이페이지로 이동" 메인 버튼 + "이전 진단 내역 보기" 링크로 분리
- 마이페이지 이동 버튼 추가 (`/mypage`)
- "이미 진단받은 적이 있으신가요?" 안내 문구 추가
- "이전 진단 내역보기" 페이지가 작업중이라 일단 메인으로 이동되게 돌렸습니다 나중에 수정예정!


<br />

## 💬 리뷰 요구사항 ( 선택 )

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 <br />
> ex. 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **새로운 기능**
  * 진단 완료 페이지의 하단 영역이 개편되었습니다. 기존의 단순한 단일 버튼 대신, 마이페이지로 이동하는 주요 버튼, 이전 진단 경험 여부를 확인하는 안내 메시지, 그리고 진단 기록을 조회하는 별도의 링크를 포함한 새로운 구조로 변경되었습니다. 이를 통해 사용자가 다음 단계로 더욱 쉽고 직관적으로 진행할 수 있게 되었으며, 전반적인 사용자 경험이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->