### PR TITLE
#103 design: 로그인 화면 약관 추가

### DIFF
--- a/src/app/(default)/login/page.tsx
+++ b/src/app/(default)/login/page.tsx
@@ -2,6 +2,7 @@ import { Suspense } from "react";
 import { Button } from "@/components/ui/button";
 import Image from "next/image";
 import LoginErrorToast from "@/components/login/login-error-toast";
+import { EXTERNAL_LINKS } from "@/utils/external-links";
 
 const BASE_URL = "https://api.musicpeak.site/oauth2/authorization";
 
@@ -22,45 +23,79 @@ export default function Login() {
           </p>
         </div>
       </div>
-      <div className="flex flex-col gap-2">
-        <Button
-          asChild
-          variant="btnWhite"
-          size="full"
-          className="text-[#000000]"
-        >
-          <a href={`${BASE_URL}/google`}>
-            <Image
-              src={"/google.png"}
-              alt="Google Logo"
-              width={30}
-              height={30}
-            />
-            구글로 시작하기
+      <div className="flex flex-col gap-6">
+        <div className="flex flex-col gap-2">
+          <Button
+            asChild
+            variant="btnWhite"
+            size="full"
+            className="text-[#000000]"
+          >
+            <a href={`${BASE_URL}/google`}>
+              <Image
+                src={"/google.png"}
+                alt="Google Logo"
+                width={30}
+                height={30}
+              />
+              구글로 시작하기
+            </a>
+          </Button>
+          <Button
+            asChild
+            variant="btnWhite"
+            size="full"
+            className="border-none bg-[#FFE812] text-[#000000]"
+          >
+            <a href={`${BASE_URL}/kakao`}>
+              <Image
+                src={"/kakao.png"}
+                alt="Kakao Logo"
+                width={30}
+                height={30}
+              />
+              카카오로 시작하기
+            </a>
+          </Button>
+          <Button
+            asChild
+            variant="btnWhite"
+            size="full"
+            className="text-font-white border-none bg-[#03CF5D]"
+          >
+            <a href={`${BASE_URL}/naver`}>
+              <Image
+                src={"/naver.png"}
+                alt="Naver Logo"
+                width={30}
+                height={30}
+              />
+              네이버로 시작하기
+            </a>
+          </Button>
+        </div>
+        <p className="text-font-light c1-medium text-center">
+          소셜 로그인 가입 시 본{" "}
+          <a
+            href={EXTERNAL_LINKS.TERMS}
+            className="underline"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            서비스이용약관
+          </a>{" "}
+          및{" "}
+          <a
+            href={EXTERNAL_LINKS.PRIVACY}
+            className="underline"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            개인정보처리방침
           </a>
-        </Button>
-        <Button
-          asChild
-          variant="btnWhite"
-          size="full"
-          className="border-none bg-[#FFE812] text-[#000000]"
-        >
-          <a href={`${BASE_URL}/kakao`}>
-            <Image src={"/kakao.png"} alt="Kakao Logo" width={30} height={30} />
-            카카오로 시작하기
-          </a>
-        </Button>
-        <Button
-          asChild
-          variant="btnWhite"
-          size="full"
-          className="text-font-white border-none bg-[#03CF5D]"
-        >
-          <a href={`${BASE_URL}/naver`}>
-            <Image src={"/naver.png"} alt="Naver Logo" width={30} height={30} />
-            네이버로 시작하기
-          </a>
-        </Button>
+          에 <br />
+          동의하시는 것으로 간주됩니다.
+        </p>
       </div>
     </main>
   );

--- a/src/utils/external-links.ts
+++ b/src/utils/external-links.ts
@@ -1,0 +1,6 @@
+export const EXTERNAL_LINKS = {
+  TERMS:
+    "https://www.notion.so/goormkdx/PEAK-34bc0ff4ce318055b56de402af767268?source=copy_link",
+  PRIVACY:
+    "https://www.notion.so/goormkdx/PEAK-356c0ff4ce31806dbf70c98b5942486c?source=copy_link",
+};


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex. #103

<br />

## 📝 작업 내용

<img width="1567" height="1061" alt="image" src="https://github.com/user-attachments/assets/46e8a234-b313-4455-a843-dc9c310d9f29" />

외부 링크(이용약관, 개인정보처리방침)를 공통 유틸 상수로 분리하고 로그인 페이지에 적용했습니다.

### 주요 변경
- `src/utils/external-links.ts` 추가 — 노션 기반 이용약관/개인정보처리방침 URL 상수 관리
- `src/app/(default)/login/page.tsx` — 내부 라우트(`/terms`, `/privacy`) → `EXTERNAL_LINKS` 상수로 교체, 
`<a target="_blank">` 적용

<br />

## 💬 리뷰 요구사항 ( 선택 )

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 <br />
> ex. 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * 로그인 페이지에 약관 및 개인정보 처리방침 링크 추가

* **Style**
  * 소셜 로그인 버튼 레이아웃 개선 및 스타일 일관성 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->