### PR TITLE
#110 feat: 진단 결과 페이지 API 연결

### DIFF
--- a/src/app/(default)/report/[id]/page.tsx
+++ b/src/app/(default)/report/[id]/page.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import BackButton from "@/components/common/back-button";
+import ErrorView from "@/components/common/error-view";
 import { Spinner } from "@/components/ui/spinner";
 import { Button } from "@/components/ui/button";
 import { Calendar, ChevronRight } from "lucide-react";
 import { toJpeg } from "html-to-image";
 import { toast } from "sonner";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useParams } from "next/navigation";
 import { getAnalysisPage, getDiagnosisDetail } from "@/lib/api/music-promotion";
 import { GetDiagnosisDetailRes } from "@/types/api-response";
@@ -17,26 +18,27 @@ export default function ReportDetailPage() {
 
   const [data, setData] = useState<GetDiagnosisDetailRes | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const [isError, setIsError] = useState(false);
+
+  const load = useCallback(async () => {
+    setIsLoading(true);
+    setIsError(false);
+    try {
+      const analysisPage = await getAnalysisPage(promotionId);
+      const cards = analysisPage.diagnosisSection.diagnosisCards;
+      if (!cards.length) return;
+      const detail = await getDiagnosisDetail(promotionId, cards[0].diagnosisId);
+      setData(detail);
+    } catch {
+      setIsError(true);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [promotionId]);
 
   useEffect(() => {
-    const load = async () => {
-      try {
-        const analysisPage = await getAnalysisPage(promotionId);
-        const cards = analysisPage.diagnosisSection.diagnosisCards;
-        if (!cards.length) return;
-        const detail = await getDiagnosisDetail(
-          promotionId,
-          cards[0].diagnosisId
-        );
-        setData(detail);
-      } catch {
-        toast.error("데이터를 불러오는데 실패했어요.");
-      } finally {
-        setIsLoading(false);
-      }
-    };
     load();
-  }, [promotionId]);
+  }, [load]);
 
   const handleSaveImage = async () => {
     const target = document.getElementById("app-root");
@@ -63,6 +65,16 @@ export default function ReportDetailPage() {
       <div className="flex min-h-screen items-center justify-center">
         <Spinner className="text-main" />
       </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <ErrorView
+        title={"요청하신 화면을\n불러오지 못했어요"}
+        description={"페이지가 없거나 연결이 잠시 불안정해요.\n잠시 후 다시 시도해주세요."}
+        onAction={load}
+      />
     );
   }
 

--- a/src/app/(default)/report/[id]/page.tsx
+++ b/src/app/(default)/report/[id]/page.tsx
@@ -5,14 +5,28 @@ import { Button } from "@/components/ui/button";
 import { Calendar, ChevronRight } from "lucide-react";
 import { toJpeg } from "html-to-image";
 import { toast } from "sonner";
-
-const STATS = [
-  { label: "게시글 공유수", value: 13 },
-  { label: "프로필 방문자수", value: 6 },
-  { label: "링크 클릭수", value: 0 },
-];
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import { getAnalysisPage, getDiagnosisDetail } from "@/lib/api/music-promotion";
+import { GetDiagnosisDetailRes } from "@/types/api-response";
 
 export default function ReportDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const promotionId = Number(id);
+
+  const [data, setData] = useState<GetDiagnosisDetailRes | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      const analysisPage = await getAnalysisPage(promotionId);
+      const cards = analysisPage.diagnosisSection.diagnosisCards;
+      if (!cards.length) return;
+      const detail = await getDiagnosisDetail(promotionId, cards[0].diagnosisId);
+      setData(detail);
+    };
+    load();
+  }, [promotionId]);
+
   const handleSaveImage = async () => {
     const target = document.getElementById("app-root");
     if (!target) return;
@@ -31,82 +45,85 @@ export default function ReportDetailPage() {
     }
   };
 
+  const [from, to] = data?.diagnosis.highlightSection.split(" > ") ?? [];
+
   return (
     <>
       <BackButton href="/report" />
       <main className="flex flex-col gap-9">
         <div className="bg-allwhite flex min-h-screen flex-col gap-9 pb-24">
-        <div className="mt-7 flex flex-col items-start gap-1">
-          <h2 className="h2-bold text-font-basic">
-            김피크님의 홍보 현황이에요
-          </h2>
-          <div className="border-border text-font-middle flex items-center gap-2 rounded-full border px-4 py-2">
-            <Calendar size={16} />
-            <span className="p2-medium">26.04.01 - 26.04.14</span>
-          </div>
-        </div>
-
-        <div className="flex flex-col gap-4">
-          <section className="grid grid-cols-3 gap-5 text-center">
-            {STATS.map(({ label, value }) => (
-              <div
-                key={label}
-                className="box-item rounded-r2 bg-grey1 flex min-h-26 flex-col justify-start gap-2.5 p-2.5"
-              >
-                <div className="c1-medium text-font-middle rounded-r1 w-full bg-white py-1">
-                  {label}
-                </div>
-                <h1 className="text-main text-4xl font-semibold">{value}</h1>
-              </div>
-            ))}
-          </section>
-
-          <section className="border-border rounded-r3 flex flex-col gap-4 border p-5">
-            <h6 className="text-font-middle p1-bold flex flex-col gap-1">
-              지금 홍보가 막힌 단계는
-              <span className="text-main-dark1 h3-bold flex items-center gap-1">
-                피드 게시글
-                <ChevronRight size={24} />
-                프로필 방문
-              </span>
-              이에요
-            </h6>
-            <div className="bg-brand-gradient rounded-r2 p-4 break-keep whitespace-pre-line text-white">
-              게시글 반응은 있지만, 프로필 링크까지 이어지지 않았어요.
-              <br />
-              <strong>콘텐츠에 링크로 유도하는 장치가 필요해요.</strong>
+          <div className="mt-7 flex flex-col items-start gap-1">
+            <h2 className="h2-bold text-font-basic">
+              홍보 현황이에요
+            </h2>
+            <div className="border-border text-font-middle flex items-center gap-2 rounded-full border px-4 py-2">
+              <Calendar size={16} />
+              <span className="p2-medium">{data?.periodLabel ?? "-"}</span>
             </div>
+          </div>
+
+          <div className="flex flex-col gap-4">
+            <section className="grid grid-cols-3 gap-5 text-center">
+              {[
+                { label: "팔로워 대비 반응률", value: data?.summaryMetrics.followerEngagementRate },
+                { label: "반응 대비 홍보 클릭률", value: data?.summaryMetrics.promoClickRateByEngagement },
+                { label: "홍보 대비 스트리밍 클릭률", value: data?.summaryMetrics.streamingClickRateByPromoClick },
+              ].map(({ label, value }) => (
+                <div
+                  key={label}
+                  className="box-item rounded-r2 bg-grey1 flex min-h-26 flex-col justify-start gap-2.5 p-2.5"
+                >
+                  <div className="c1-medium text-font-middle rounded-r1 w-full bg-white py-1">
+                    {label}
+                  </div>
+                  <h1 className="text-main text-4xl font-semibold">
+                    {value ?? "-"}
+                  </h1>
+                </div>
+              ))}
+            </section>
+
+            <section className="border-border rounded-r3 flex flex-col gap-4 border p-5">
+              <h6 className="text-font-middle p1-bold flex flex-col gap-1">
+                지금 홍보가 막힌 단계는
+                <span className="text-main-dark1 h3-bold flex items-center gap-1">
+                  {from}
+                  <ChevronRight size={24} />
+                  {to}
+                </span>
+                이에요
+              </h6>
+              <div className="bg-brand-gradient rounded-r2 p-4 break-keep whitespace-pre-line text-white">
+                {data?.headline}
+              </div>
+            </section>
+          </div>
+
+          <section className="flex flex-col gap-2">
+            <h5 className="h3-bold">지금 바로 바꿔보세요</h5>
+            <ul className="flex flex-col gap-2">
+              {data?.action && (
+                <li className="bg-grey1 grid grid-cols-[1fr] items-center gap-5 rounded-2xl px-5 py-5">
+                  <div className="flex flex-col gap-1 text-wrap break-keep whitespace-pre-line">
+                    <h5 className="p1-bold text-main">{data.action.title}</h5>
+                    <p className="p2-medium text-font-middle">{data.action.metric}</p>
+                    <p className="p2-regular text-font-middle">{data.action.details}</p>
+                  </div>
+                </li>
+              )}
+            </ul>
           </section>
         </div>
 
-        <section className="flex flex-col gap-2">
-          <h5 className="h3-bold">이렇게 해보세요</h5>
-          <ul className="flex flex-col gap-2">
-            <li className="bg-grey1 grid grid-cols-[1fr] items-center gap-5 rounded-2xl px-5 py-5">
-              <div className="flex flex-col gap-1 text-wrap break-keep whitespace-pre-line">
-                <h5 className="p1-bold text-main">
-                  게시글 끝에 링크 유도 문구 넣기
-                </h5>
-                <p className="p2-regular text-font-middle">
-                  {
-                    '"프로필 링크에서 바로 들어보세요"\n한 줄만 추가해도 클릭률이 달라져요'
-                  }
-                </p>
-              </div>
-            </li>
-          </ul>
-        </section>
-      </div>
-
-      <div
-        data-capture-ignore
-        className="fixed right-1/2 bottom-15 flex w-full max-w-(--max-width) translate-x-1/2 justify-center px-5"
-      >
-        <Button variant="btnPurple" size="full" onClick={handleSaveImage}>
-          이미지 저장하기
-        </Button>
-      </div>
-    </main>
+        <div
+          data-capture-ignore
+          className="fixed right-1/2 bottom-15 flex w-full max-w-(--max-width) translate-x-1/2 justify-center px-5"
+        >
+          <Button variant="btnPurple" size="full" onClick={handleSaveImage}>
+            이미지 저장하기
+          </Button>
+        </div>
+      </main>
     </>
   );
 }

--- a/src/app/(default)/report/[id]/page.tsx
+++ b/src/app/(default)/report/[id]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import BackButton from "@/components/common/back-button";
+import { Spinner } from "@/components/ui/spinner";
 import { Button } from "@/components/ui/button";
 import { Calendar, ChevronRight } from "lucide-react";
 import { toJpeg } from "html-to-image";
@@ -15,14 +16,24 @@ export default function ReportDetailPage() {
   const promotionId = Number(id);
 
   const [data, setData] = useState<GetDiagnosisDetailRes | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     const load = async () => {
-      const analysisPage = await getAnalysisPage(promotionId);
-      const cards = analysisPage.diagnosisSection.diagnosisCards;
-      if (!cards.length) return;
-      const detail = await getDiagnosisDetail(promotionId, cards[0].diagnosisId);
-      setData(detail);
+      try {
+        const analysisPage = await getAnalysisPage(promotionId);
+        const cards = analysisPage.diagnosisSection.diagnosisCards;
+        if (!cards.length) return;
+        const detail = await getDiagnosisDetail(
+          promotionId,
+          cards[0].diagnosisId
+        );
+        setData(detail);
+      } catch {
+        toast.error("데이터를 불러오는데 실패했어요.");
+      } finally {
+        setIsLoading(false);
+      }
     };
     load();
   }, [promotionId]);
@@ -47,15 +58,21 @@ export default function ReportDetailPage() {
 
   const [from, to] = data?.diagnosis.highlightSection.split(" > ") ?? [];
 
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <Spinner className="text-main" />
+      </div>
+    );
+  }
+
   return (
     <>
       <BackButton href="/report" />
       <main className="flex flex-col gap-9">
         <div className="bg-allwhite flex min-h-screen flex-col gap-9 pb-24">
           <div className="mt-7 flex flex-col items-start gap-1">
-            <h2 className="h2-bold text-font-basic">
-              홍보 현황이에요
-            </h2>
+            <h2 className="h2-bold text-font-basic">홍보 현황이에요</h2>
             <div className="border-border text-font-middle flex items-center gap-2 rounded-full border px-4 py-2">
               <Calendar size={16} />
               <span className="p2-medium">{data?.periodLabel ?? "-"}</span>
@@ -65,9 +82,18 @@ export default function ReportDetailPage() {
           <div className="flex flex-col gap-4">
             <section className="grid grid-cols-3 gap-5 text-center">
               {[
-                { label: "팔로워 대비 반응률", value: data?.summaryMetrics.followerEngagementRate },
-                { label: "반응 대비 홍보 클릭률", value: data?.summaryMetrics.promoClickRateByEngagement },
-                { label: "홍보 대비 스트리밍 클릭률", value: data?.summaryMetrics.streamingClickRateByPromoClick },
+                {
+                  label: "팔로워 대비 반응률",
+                  value: data?.summaryMetrics.followerEngagementRate,
+                },
+                {
+                  label: "반응 대비 홍보 클릭률",
+                  value: data?.summaryMetrics.promoClickRateByEngagement,
+                },
+                {
+                  label: "홍보 대비 스트리밍 클릭률",
+                  value: data?.summaryMetrics.streamingClickRateByPromoClick,
+                },
               ].map(({ label, value }) => (
                 <div
                   key={label}
@@ -106,8 +132,12 @@ export default function ReportDetailPage() {
                 <li className="bg-grey1 grid grid-cols-[1fr] items-center gap-5 rounded-2xl px-5 py-5">
                   <div className="flex flex-col gap-1 text-wrap break-keep whitespace-pre-line">
                     <h5 className="p1-bold text-main">{data.action.title}</h5>
-                    <p className="p2-medium text-font-middle">{data.action.metric}</p>
-                    <p className="p2-regular text-font-middle">{data.action.details}</p>
+                    <p className="p2-medium text-font-middle">
+                      {data.action.metric}
+                    </p>
+                    <p className="p2-regular text-font-middle">
+                      {data.action.details}
+                    </p>
                   </div>
                 </li>
               )}

--- a/src/lib/api/music-promotion.ts
+++ b/src/lib/api/music-promotion.ts
@@ -3,6 +3,8 @@ import { MusicPromotionInfo } from "@/types/album";
 import {
   AnalysisJobCreateRes,
   CreateMusicPromotionRes,
+  GetAnalysisPageRes,
+  GetDiagnosisDetailRes,
   GetMusicPromotionRes,
   GetMyPagePromotionsRes,
 } from "@/types/api-response";
@@ -100,6 +102,45 @@ export async function analyzePromotion(
     return res;
   } catch {
     throw new Error("[music-promotion]: AI 분석 요청 실패");
+  }
+}
+
+/**
+ * 홍보 분석 페이지 조회
+ * [GET] /music-promotions/{promotionId}/analysis-page
+ */
+export async function getAnalysisPage(
+  promotionId: number
+): Promise<GetAnalysisPageRes> {
+  try {
+    const res = await fetcher<GetAnalysisPageRes>(
+      `/music-promotions/${promotionId}/analysis-page`,
+      { method: "GET" }
+    );
+    return res;
+  } catch (e) {
+    console.error("[music-promotion]: 홍보 분석 페이지 조회 실패");
+    throw e;
+  }
+}
+
+/**
+ * 진단 결과 상세 조회
+ * [GET] /music-promotions/{promotionId}/diagnoses/{diagnosisId}
+ */
+export async function getDiagnosisDetail(
+  promotionId: number,
+  diagnosisId: number
+): Promise<GetDiagnosisDetailRes> {
+  try {
+    const res = await fetcher<GetDiagnosisDetailRes>(
+      `/music-promotions/${promotionId}/diagnoses/${diagnosisId}`,
+      { method: "GET" }
+    );
+    return res;
+  } catch (e) {
+    console.error("[music-promotion]: 진단 결과 상세 조회 실패");
+    throw e;
   }
 }
 

--- a/src/types/api-response.ts
+++ b/src/types/api-response.ts
@@ -47,6 +47,43 @@ export interface AnalysisJobCreateRes {
   status: string;
 }
 
+// 홍보 분석 페이지 조회 Res
+export interface DiagnosisCard {
+  diagnosisId: number;
+  diagnosedDate: string;
+  bottleneckType: string;
+  headline: string;
+  actionTitle: string;
+  unread: boolean;
+}
+
+export interface GetAnalysisPageRes {
+  promotionId: number;
+  diagnosisSection: {
+    status: string;
+    diagnosisCards: DiagnosisCard[];
+  };
+}
+
+// 진단 결과 상세 조회 Res
+export interface GetDiagnosisDetailRes {
+  headline: string;
+  periodLabel: string;
+  summaryMetrics: {
+    followerEngagementRate: number;
+    promoClickRateByEngagement: number;
+    streamingClickRateByPromoClick: number;
+  };
+  diagnosis: {
+    highlightSection: string;
+  };
+  action: {
+    title: string;
+    metric: string;
+    details: string;
+  };
+}
+
 // 뮤지션 홍보 조회 Res
 export interface GetMusicPromotionRes {
   promotionId: number;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex. #110

<br />

## 📝 작업 내용

## 진단 결과 페이지 API 연결

### 변경 사항

**타입 추가** (`src/types/api-response.ts`)
- `DiagnosisCard` — 진단 카드 타입
- `GetAnalysisPageRes` — 홍보 분석 페이지 조회 응답 타입
- `GetDiagnosisDetailRes` — 진단 결과 상세 조회 응답 타입

**API 함수 추가** (`src/lib/api/music-promotion.ts`)
- `getAnalysisPage` — `GET /api/music-promotions/{promotionId}/analysis-page`
- `getDiagnosisDetail` — `GET /api/music-promotions/{promotionId}/diagnoses/{diagnosisId}`

**페이지 연결** (`src/app/(default)/report/[id]/page.tsx`)
- 하드코딩 더미 데이터 제거
- URL `[id]` → `promotionId`로 사용
- `analysis-page` API로 `diagnosisId` 추출 후 진단 결과 상세 조회
- `periodLabel`, `summaryMetrics`, `headline`, `highlightSection`, `action` 실데이터로 교체

### 미완료
- `diagnosisId`: 현재 최신 카드(`cards[0]`) 기준 — 목록 페이지 퍼블 완료 후 연결 예정


<br />

## 💬 리뷰 요구사항 ( 선택 )

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 <br />
> ex. 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 리포트 상세 페이지가 정확한 분석 데이터를 동적으로 표시하도록 업데이트되었습니다.
  * 리포트 기간, 통계 지표, 분석 결과, 맞춤형 추천이 실제 데이터로 제공됩니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devTeam-PEAK/FE/pull/111)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->