### PR TITLE
#112 fix: 4.1.6 진단결과화면 데이터 수정

### DIFF
--- a/src/app/(default)/report/[id]/page.tsx
+++ b/src/app/(default)/report/[id]/page.tsx
@@ -106,10 +106,10 @@ export default function ReportDetailPage() {
     <>
       <BackButton href="/report" />
       <main className="flex flex-col gap-9">
-        <div className="bg-allwhite flex min-h-screen flex-col gap-9 pb-24">
+        <div className="bg-allwhite flex min-h-screen flex-col gap-9">
           <div className="mt-7 flex flex-col items-start gap-1">
             <h2 className="h2-bold text-font-basic">
-              {activityName}님의 홍보 현황이에요
+              {activityName || "아티스트"}님의 홍보 현황이에요
             </h2>
             <div className="border-border text-font-middle flex items-center gap-2 rounded-full border px-4 py-2">
               <Calendar size={16} />
@@ -186,15 +186,15 @@ export default function ReportDetailPage() {
               )}
             </ul>
           </section>
-        </div>
 
-        <div
-          data-capture-ignore
-          className="fixed right-1/2 bottom-15 flex w-full max-w-(--max-width) translate-x-1/2 justify-center px-5"
-        >
-          <Button variant="btnPurple" size="full" onClick={handleSaveImage}>
-            이미지 저장하기
-          </Button>
+          <div
+            data-capture-ignore
+            className="flex w-full max-w-(--max-width) justify-center px-5"
+          >
+            <Button variant="btnPurple" size="full" onClick={handleSaveImage}>
+              이미지 저장하기
+            </Button>
+          </div>
         </div>
       </main>
     </>

--- a/src/app/(default)/report/[id]/page.tsx
+++ b/src/app/(default)/report/[id]/page.tsx
@@ -9,7 +9,11 @@ import { toJpeg } from "html-to-image";
 import { toast } from "sonner";
 import { useCallback, useEffect, useState } from "react";
 import { useParams } from "next/navigation";
-import { getAnalysisPage, getDiagnosisDetail } from "@/lib/api/music-promotion";
+import {
+  getAnalysisPage,
+  getDiagnosisDetail,
+  getMusicPromotion,
+} from "@/lib/api/music-promotion";
 import { GetDiagnosisDetailRes } from "@/types/api-response";
 
 export default function ReportDetailPage() {
@@ -17,6 +21,8 @@ export default function ReportDetailPage() {
   const promotionId = Number(id);
 
   const [data, setData] = useState<GetDiagnosisDetailRes | null>(null);
+  const [activityName, setActivityName] = useState<string>("");
+  const [diagnosedDate, setDiagnosedDate] = useState<string>("");
   const [isLoading, setIsLoading] = useState(true);
   const [isError, setIsError] = useState(false);
 
@@ -24,10 +30,18 @@ export default function ReportDetailPage() {
     setIsLoading(true);
     setIsError(false);
     try {
-      const analysisPage = await getAnalysisPage(promotionId);
+      const [analysisPage, promotion] = await Promise.all([
+        getAnalysisPage(promotionId),
+        getMusicPromotion(promotionId),
+      ]);
+      setActivityName(promotion.activityName);
       const cards = analysisPage.diagnosisSection.diagnosisCards;
       if (!cards.length) return;
-      const detail = await getDiagnosisDetail(promotionId, cards[0].diagnosisId);
+      setDiagnosedDate(cards[0].diagnosedDate);
+      const detail = await getDiagnosisDetail(
+        promotionId,
+        cards[0].diagnosisId
+      );
       setData(detail);
     } catch {
       setIsError(true);
@@ -60,6 +74,14 @@ export default function ReportDetailPage() {
 
   const [from, to] = data?.diagnosis.highlightSection.split(" > ") ?? [];
 
+  const todayLabel = (() => {
+    const d = new Date();
+    const yy = String(d.getFullYear()).slice(-2);
+    const mm = String(d.getMonth() + 1).padStart(2, "0");
+    const dd = String(d.getDate()).padStart(2, "0");
+    return `${yy}.${mm}.${dd}`;
+  })();
+
   if (isLoading) {
     return (
       <div className="flex min-h-screen items-center justify-center">
@@ -72,7 +94,9 @@ export default function ReportDetailPage() {
     return (
       <ErrorView
         title={"요청하신 화면을\n불러오지 못했어요"}
-        description={"페이지가 없거나 연결이 잠시 불안정해요.\n잠시 후 다시 시도해주세요."}
+        description={
+          "페이지가 없거나 연결이 잠시 불안정해요.\n잠시 후 다시 시도해주세요."
+        }
         onAction={load}
       />
     );
@@ -84,10 +108,14 @@ export default function ReportDetailPage() {
       <main className="flex flex-col gap-9">
         <div className="bg-allwhite flex min-h-screen flex-col gap-9 pb-24">
           <div className="mt-7 flex flex-col items-start gap-1">
-            <h2 className="h2-bold text-font-basic">홍보 현황이에요</h2>
+            <h2 className="h2-bold text-font-basic">
+              {activityName}님의 홍보 현황이에요
+            </h2>
             <div className="border-border text-font-middle flex items-center gap-2 rounded-full border px-4 py-2">
               <Calendar size={16} />
-              <span className="p2-medium">{data?.periodLabel ?? "-"}</span>
+              <span className="p2-medium">
+                {diagnosedDate ? `${diagnosedDate} - ${todayLabel}` : "-"}
+              </span>
             </div>
           </div>
 

--- a/src/app/(default)/report/[id]/page.tsx
+++ b/src/app/(default)/report/[id]/page.tsx
@@ -42,6 +42,8 @@ export default function ReportDetailPage() {
         setIsEmpty(true);
         return;
       }
+
+      // 일단 첫번째카드 diagnosisId로 상세조회 나중에 목록생기면 삭제예정
       setDiagnosedDate(cards[0].diagnosedDate);
       const detail = await getDiagnosisDetail(
         promotionId,

--- a/src/app/(default)/report/[id]/page.tsx
+++ b/src/app/(default)/report/[id]/page.tsx
@@ -25,10 +25,12 @@ export default function ReportDetailPage() {
   const [diagnosedDate, setDiagnosedDate] = useState<string>("");
   const [isLoading, setIsLoading] = useState(true);
   const [isError, setIsError] = useState(false);
+  const [isEmpty, setIsEmpty] = useState(false);
 
   const load = useCallback(async () => {
     setIsLoading(true);
     setIsError(false);
+    setIsEmpty(false);
     try {
       const [analysisPage, promotion] = await Promise.all([
         getAnalysisPage(promotionId),
@@ -36,7 +38,10 @@ export default function ReportDetailPage() {
       ]);
       setActivityName(promotion.activityName);
       const cards = analysisPage.diagnosisSection.diagnosisCards;
-      if (!cards.length) return;
+      if (!cards.length) {
+        setIsEmpty(true);
+        return;
+      }
       setDiagnosedDate(cards[0].diagnosedDate);
       const detail = await getDiagnosisDetail(
         promotionId,
@@ -101,6 +106,8 @@ export default function ReportDetailPage() {
       />
     );
   }
+
+  if (isEmpty || !data) return null;
 
   return (
     <>

--- a/src/app/(default)/report/[id]/page.tsx
+++ b/src/app/(default)/report/[id]/page.tsx
@@ -4,7 +4,7 @@ import BackButton from "@/components/common/back-button";
 import ErrorView from "@/components/common/error-view";
 import { Spinner } from "@/components/ui/spinner";
 import { Button } from "@/components/ui/button";
-import { Calendar, ChevronRight } from "lucide-react";
+import { ArrowBigRight, Calendar, ChevronRight } from "lucide-react";
 import { toJpeg } from "html-to-image";
 import { toast } from "sonner";
 import { useCallback, useEffect, useState } from "react";
@@ -139,7 +139,7 @@ export default function ReportDetailPage() {
                   key={label}
                   className="box-item rounded-r2 bg-grey1 flex min-h-26 flex-col justify-start gap-2.5 p-2.5"
                 >
-                  <div className="c1-medium text-font-middle rounded-r1 w-full bg-white py-1">
+                  <div className="c1-medium text-font-middle rounded-r1 w-full bg-white py-1 break-keep">
                     {label}
                   </div>
                   <h1 className="text-main text-4xl font-semibold">
@@ -171,10 +171,13 @@ export default function ReportDetailPage() {
               {data?.action && (
                 <li className="bg-grey1 grid grid-cols-[1fr] items-center gap-5 rounded-2xl px-5 py-5">
                   <div className="flex flex-col gap-1 text-wrap break-keep whitespace-pre-line">
-                    <h5 className="p1-bold text-main">{data.action.title}</h5>
-                    <p className="p2-medium text-font-middle">
+                    <h5 className="p1-bold text-font-basic">
+                      {data.action.title}
+                    </h5>
+                    <h6 className="p2-bold text-main flex items-start gap-1">
+                      <ArrowBigRight size={20} fill="currentColor" />
                       {data.action.metric}
-                    </p>
+                    </h6>
                     <p className="p2-regular text-font-middle">
                       {data.action.details}
                     </p>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex. #112

<br />

## 📝 작업 내용

<img width="320" height="" alt="report (1)" src="https://github.com/user-attachments/assets/ec8b3cc1-86b1-4a11-a71d-2aa84b35fb9e" />

### API 연결
- 하드코딩 목데이터 제거 후 실제 API 연결
- `getAnalysisPage` + `getMusicPromotion` 병렬 호출 (`Promise.all`)
- `getDiagnosisDetail`로 진단 상세 데이터 조회

### 데이터 바인딩
- 헤더 아티스트명: `activityName` 연결 (빈 값 시 "아티스트" 폴백)
- 진단 기간: `diagnosedDate - 오늘` 형식으로 표시 (`YY.MM.DD`)
- 지표 3종, 병목 단계, 헤드라인, 액션 카드 실데이터 연결

### UI
- `ArrowBigRight` 아이콘 `fill="currentColor"` 적용
- 지표 라벨 `break-keep` 추가

### 상태 처리
- 로딩: 스피너
- 에러: 에러 뷰 (재시도 버튼)
- 빈 상태 (진단 카드 없음): `null` 반환 (추후 디자인 적용 예정)

<br />

## 💬 리뷰 요구사항 ( 선택 )

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 <br />
> ex. 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 개인화된 제목: 활동 이름 기반 제목과 진단 날짜–오늘 범위 표시

* **버그 수정**
  * 진단 카드가 없을 때 로더 중단 및 빈 상태 처리(컴포넌트 렌더링 중단)
  * 오류 뷰의 재시도 동작이 동일한 로드 흐름을 호출하도록 수정

* **스타일**
  * 메트릭 카드 라벨 스타일 조정
  * 액션 항목에 메트릭 행 및 아이콘 추가
  * 이미지 저장 버튼을 인플로우 플렉스 레이아웃으로 이동

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devTeam-PEAK/FE/pull/113)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->