### PR TITLE
#125 refactor: 홍보 분석 페이지(4.1.3) 코드 리뷰 반영 #125

### DIFF
--- a/src/components/mypage/album-analysis-action-button.tsx
+++ b/src/components/mypage/album-analysis-action-button.tsx
@@ -22,7 +22,7 @@ export default function AlbumAnalysisActionButton({
   };
 
   // 홍보 페이지 삭제
-  const handDelete = () => {
+  const handleDelete = () => {
     openAlertModal({
       type: "confirm",
       variant: "danger",
@@ -73,7 +73,7 @@ export default function AlbumAnalysisActionButton({
         <Button
           variant="btnPurpleSub"
           className="p2-bold h-9 flex-1 rounded-full"
-          onClick={handDelete}
+          onClick={handleDelete}
         >
           {" "}
           홍보 페이지 삭제

--- a/src/components/mypage/analysis-streaming-section.tsx
+++ b/src/components/mypage/analysis-streaming-section.tsx
@@ -22,7 +22,7 @@ export default function StreamingSection({ streamingLinks }: Props) {
 
           return (
             <li
-              key={streamingItem.label}
+              key={item.streamingCode}
               className="flex justify-between px-1 py-3"
             >
               <div className="flex items-center gap-3">

--- a/src/components/mypage/diagnosis-item-card.tsx
+++ b/src/components/mypage/diagnosis-item-card.tsx
@@ -25,7 +25,7 @@ export default function DiagnosisItemCard({
 }: Props) {
   const router = useRouter();
 
-  const isAnalyzing = status === "RUNNING"; // 진단중
+  const isAnalyzing = status === "PENDING" || status === "RUNNING"; // 진단중
   const isAnalyzed = status === "COMPLETED"; // 진단완료
 
   const title = isAnalyzing ? "진단 결과 대기중이에요" : actionTitle;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #125

<br />

## 📝 작업 내용

- 홍보 삭제 함수명 오타 수정
- 스트리밍 리스트 아이템 Key 개선
- PENDING 상태 진단중으로 체크
