### PR TITLE
#128 fix: 앨범 생성 및 수정 API 중복 요청 방지

### DIFF
--- a/src/app/(default)/album/_client-album-page.tsx
+++ b/src/app/(default)/album/_client-album-page.tsx
@@ -66,6 +66,8 @@ export default function AlbumPage() {
     description: false,
   });
 
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
   useEffect(() => {
     if (!editId) return;
 
@@ -220,9 +222,13 @@ export default function AlbumPage() {
   };
 
   const handleSubmit = async () => {
+    if (isSubmitting) return;
+
     const isValid = validate();
 
     if (!isValid) return;
+
+    setIsSubmitting(true);
 
     try {
       // 1. 새 이미지를 선택했을 때 이미지 업로드
@@ -279,6 +285,8 @@ export default function AlbumPage() {
         isEditMode ? "수정에 실패했습니다." : "홍보 링크 생성에 실패했습니다.",
         { position: "bottom-center" }
       );
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
@@ -463,7 +471,12 @@ export default function AlbumPage() {
           />
         </section>
 
-        <Button variant="btnPurple" size="full" onClick={handleSubmit}>
+        <Button
+          variant="btnPurple"
+          size="full"
+          onClick={handleSubmit}
+          disabled={isSubmitting}
+        >
           {isEditMode ? "수정 완료" : "홍보 링크 만들기"}
         </Button>
       </main>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #128

<br />

## 📝 작업 내용

- 앨범 정보 입력 페이지(2.1) 생성 & 수정 버튼 클릭 시 API 중복 요청되던 이슈 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* **폼 제출 중 중복 제출 방지** - 폼 제출 요청이 진행 중일 때 제출 버튼을 자동으로 비활성화하여 사용자가 실수로 중복 제출하는 것을 방지합니다. 요청이 완료되거나 실패하면 버튼이 다시 활성화됩니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devTeam-PEAK/FE/pull/129)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->