### PR TITLE
#131 refactor: 홈화면 로그인상태 조건부처리

### DIFF
--- a/src/app/(default)/_client-home.tsx
+++ b/src/app/(default)/_client-home.tsx
@@ -10,9 +10,10 @@ import { useOpenAlertModal } from "@/stores/alert-modal-store";
 
 interface Props {
   showIntro: boolean;
+  isLoggedIn: boolean;
 }
 
-export default function Home({ showIntro }: Props) {
+export default function Home({ showIntro, isLoggedIn }: Props) {
   const router = useRouter();
   const openAlertModal = useOpenAlertModal();
 
@@ -65,12 +66,14 @@ export default function Home({ showIntro }: Props) {
       </div>
       <div className="flex flex-col items-center gap-10">
         <HomeButtons showIntro={showIntro} />
-        <div className="c1-medium text-font-light flex flex-col gap-1 text-center">
-          내 진단 결과를 한눈에 보고 싶다면?
-          <Link href="/mypage" className="text-main c1-bold underline">
-            마이페이지로 이동
-          </Link>
-        </div>
+        {isLoggedIn && (
+          <div className="c1-medium text-font-light flex flex-col gap-1 text-center">
+            내 진단 결과를 한눈에 보고 싶다면?
+            <Link href="/mypage" className="text-main c1-bold underline">
+              마이페이지로 이동
+            </Link>
+          </div>
+        )}
       </div>
     </main>
   );

--- a/src/app/(default)/page.tsx
+++ b/src/app/(default)/page.tsx
@@ -5,6 +5,7 @@ export default async function Page() {
   const cookieStore = await cookies();
 
   const showIntro = !cookieStore.has("peak-intro-seen");
+  const isLoggedIn = cookieStore.has("isLoggedIn");
 
-  return <Home showIntro={showIntro} />;
+  return <Home showIntro={showIntro} isLoggedIn={isLoggedIn} />;
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex. #131

<br />

## 📝 작업 내용

<img width="701" height="285" alt="image" src="https://github.com/user-attachments/assets/2d3449a4-ebb9-492a-8c95-339c9c55693a" />

- 로그인 상태일 때만 "마이페이지로 이동" 링크 노출
- 서버 컴포넌트(`page.tsx`)에서 `isLoggedIn` 쿠키 확인 후 클라이언트 컴포넌트로 prop 전달

<br />

## 💬 리뷰 요구사항 ( 선택 )

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 <br />
> ex. 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 개선 사항
- 진단 결과 조회 버튼이 로그인한 사용자에게만 표시되도록 변경되었습니다. 미확인 진단 결과가 있을 경우 알림 모달이 나타나며, 확인 시 진단 결과 페이지로 이동합니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devTeam-PEAK/FE/pull/132)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->