### PR TITLE
#140 fix: diagnosis highlight 필드 구조 변경 대응

### DIFF
--- a/src/components/report/report-detail.tsx
+++ b/src/components/report/report-detail.tsx
@@ -81,7 +81,6 @@ export default function ReportDetail() {
     }
   };
 
-
   if (isLoading) {
     return (
       <div className="flex min-h-screen items-center justify-center">
@@ -174,7 +173,7 @@ export default function ReportDetail() {
             <h5 className="h3-bold">지금 바로 바꿔보세요</h5>
             {data.action && (
               <ul className="flex flex-col gap-2">
-                <li className="bg-grey1 grid grid-cols-[1fr] items-center gap-5 rounded-2xl px-5 py-5">
+                <li className="bg-grey1 rounded-2xl px-5 py-5">
                   <div className="flex flex-col gap-1 text-wrap break-keep whitespace-pre-line">
                     <h5 className="p1-bold text-font-basic">
                       {data.action.title}

--- a/src/components/report/report-detail.tsx
+++ b/src/components/report/report-detail.tsx
@@ -7,7 +7,7 @@ import { Button } from "@/components/ui/button";
 import { ArrowBigRight, Calendar, ChevronRight } from "lucide-react";
 import { toJpeg } from "html-to-image";
 import { toast } from "sonner";
-import { useCallback, useEffect, useState } from "react";
+import { Fragment, useCallback, useEffect, useState } from "react";
 import { useParams, useSearchParams } from "next/navigation";
 import { getDiagnosisDetail, getMusicPromotion } from "@/lib/api/music-promotion";
 import { GetDiagnosisDetailRes } from "@/types/api-response";
@@ -112,8 +112,7 @@ export default function ReportDetail() {
       />
     );
 
-  const from = data.diagnosis.highlightFrom;
-  const to = data.diagnosis.highlightTo;
+  const highlightParts = data.diagnosis.highlight.split(">").map((s) => s.trim());
 
   return (
     <>
@@ -155,10 +154,13 @@ export default function ReportDetail() {
             <section className="border-border rounded-r3 flex flex-col gap-4 border p-5">
               <h6 className="text-font-middle p1-bold flex flex-col gap-1">
                 지금 홍보가 막힌 단계는
-                <span className="text-main-dark1 h3-bold flex items-center gap-1">
-                  {from}
-                  <ChevronRight size={24} />
-                  {to}
+                <span className="text-main-dark1 h3-bold flex flex-wrap items-center gap-1">
+                  {highlightParts.map((part, i) => (
+                    <Fragment key={i}>
+                      {i > 0 && <ChevronRight size={24} />}
+                      {part}
+                    </Fragment>
+                  ))}
                 </span>
                 이에요
               </h6>

--- a/src/types/api-response.ts
+++ b/src/types/api-response.ts
@@ -128,8 +128,7 @@ export interface GetDiagnosisDetailRes {
     streamingClickRateByPromoClick: number;
   };
   diagnosis: {
-    highlightFrom: string;
-    highlightTo: string;
+    highlight: string;
   };
   action?: {
     title: string;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex. #140

<br />

## 📝 작업 내용
<img width="762" height="126" alt="image" src="https://github.com/user-attachments/assets/41318b05-e465-4275-a0bb-79915470166a" />

### `src/types/api-response.ts`
- `GetDiagnosisDetailRes.diagnosis` 필드 구조 변경
  - `highlightFrom`, `highlightTo` → `highlight` (단일 문자열)

### `src/components/report/report-detail.tsx`
- `highlight` 문자열을 `>` 기준으로 split해 각 파트 사이에 `ChevronRight` 아이콘 렌더링
  - `>` 없으면 텍스트만 출력, 있으면 아이콘 포함
- 불필요한 `grid grid-cols-[1fr]` 클래스 제거

<br />

## 💬 리뷰 요구사항 ( 선택 )

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 <br />
> ex. 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * 진단 결과의 하이라이트 표시 방식을 개선했습니다. 이제 여러 단계가 있는 경우 각 단계를 명확하게 구분하여 표시합니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devTeam-PEAK/FE/pull/141)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->