### PR TITLE
#138 refactor: SSE 기반 실시간 목록 업데이트 구조 개선 및 렌더링 최적화

### DIFF
--- a/src/app/(default)/mypage/page.tsx
+++ b/src/app/(default)/mypage/page.tsx
@@ -7,11 +7,17 @@ import AlbumItemCard from "@/components/mypage/album-item-card";
 import ErrorView from "@/components/common/error-view";
 import Link from "next/link";
 import { useRef, useEffect } from "react";
-import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  useInfiniteQuery,
+  useQueryClient,
+  InfiniteData,
+} from "@tanstack/react-query";
 import {
   getMyPagePromotions,
   subscribePromotionStream,
 } from "@/lib/api/music-promotion";
+import { AlbumItem } from "@/types/album";
+import { GetMyPagePromotionsRes } from "@/types/api-response";
 
 export default function MyPage() {
   const queryClient = useQueryClient();
@@ -41,11 +47,27 @@ export default function MyPage() {
   // SSE 실시간 구독
   useEffect(() => {
     const controller = subscribePromotionStream({
-      // 진단 상태 변경 시 목록 최신화
-      onPromotionUpdated: () => {
-        queryClient.invalidateQueries({
-          queryKey: ["mypage-promotions"],
-        });
+      onPromotionUpdated: (updatedPromotion: AlbumItem) => {
+        queryClient.setQueryData<InfiniteData<GetMyPagePromotionsRes>>(
+          ["mypage-promotions"],
+          (oldData) => {
+            if (!oldData) return oldData;
+
+            return {
+              ...oldData,
+
+              pages: oldData.pages.map((page) => ({
+                ...page,
+
+                promotions: page.promotions.map((promotion) =>
+                  promotion.promotionId === updatedPromotion.promotionId
+                    ? updatedPromotion
+                    : promotion
+                ),
+              })),
+            };
+          }
+        );
       },
     });
 

--- a/src/components/mypage/album-item-card.tsx
+++ b/src/components/mypage/album-item-card.tsx
@@ -5,6 +5,7 @@ import { LinkIcon, CirclePlayIcon } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { memo } from "react";
 import { formatDate } from "@/utils/date";
 import { AlbumItem } from "@/types/album";
 
@@ -13,7 +14,7 @@ interface Props {
   priority?: boolean;
 }
 
-export default function AlbumItemCard({ album, priority = false }: Props) {
+function AlbumItemCard({ album, priority = false }: Props) {
   const router = useRouter();
 
   const { analysis } = album;
@@ -112,3 +113,7 @@ export default function AlbumItemCard({ album, priority = false }: Props) {
     </div>
   );
 }
+
+export default memo(AlbumItemCard, (prev, next) => {
+  return prev.priority === next.priority && prev.album === next.album;
+});

--- a/src/lib/api/music-promotion.ts
+++ b/src/lib/api/music-promotion.ts
@@ -1,6 +1,6 @@
 import { fetcher } from "@/lib/api/common";
 import { fetchEventSource } from "@microsoft/fetch-event-source";
-import { MusicPromotionInfo } from "@/types/album";
+import { AlbumItem, MusicPromotionInfo } from "@/types/album";
 import {
   AnalysisJobCreateRes,
   CreateMusicPromotionRes,
@@ -147,7 +147,7 @@ export async function getMyPagePromotions(
 export function subscribePromotionStream({
   onPromotionUpdated,
 }: {
-  onPromotionUpdated: () => void;
+  onPromotionUpdated: (updatedPromotion: AlbumItem) => void;
 }) {
   const controller = new AbortController();
 
@@ -177,9 +177,13 @@ export function subscribePromotionStream({
         case "connected":
           return;
 
-        case "promotion-analysis-updated":
-          onPromotionUpdated();
+        case "promotion-analysis-updated": {
+          const updatedPromotion: AlbumItem = JSON.parse(event.data);
+
+          onPromotionUpdated(updatedPromotion);
+
           return;
+        }
       }
     },
 

--- a/src/types/album.ts
+++ b/src/types/album.ts
@@ -27,6 +27,7 @@ export interface AlbumItem {
     status: AnalysisStatus;
     label: string | null;
     hasUnreadResult: boolean;
+    diagnosedAt: string | null;
   };
 }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #138 

<br />

## 📝 작업 내용

**`문제`**
마이페이지에서 SSE(Server-Sent Events)를 통해 앨범 분석 상태(진단X/진단중/진단O)를 실시간으로 업데이트하고 있었습니다.

기존 구조에서는 SSE 이벤트가 발생할 때마다 `queryClient.invalidateQueries(…)`를 호출하여 전체 목록 데이터를 다시 요청하는 구조였기 때문에 **특정 앨범 하나의 상태만 바뀌어도 모든 카드 컴포넌트의 리렌더링이 발생하는 문제**가 존재했습니다.

<br />

**`개선 방향`**

변경된 앨범 카드만 렌더링시키기 위해

- 전체 refetch 제거
- 부분 캐시 업데이트
- 기존 객체 reference 유지

구조로 개선했습니다.

1) 기존의 invalidateQueries를 제거하고, TanStack Query의 setQueryData를 활용해 변경된 앨범 데이터만 캐시에서 부분 업데이트하는 구조로 변경

2)  ```promotions: page.promotions.map((promotion) =>
                  promotion.promotionId === updatedPromotion.promotionId
                    ? updatedPromotion
                    : promotion
                    ```
→ SSE 이벤트에서 전달받은 데이터를 기반으로 특정 promotion만 교체하도록 수정
→ 변경되지 않은 promotion은 기존 객체 reference를 그대로 유지

3) 앨범 카드 컴포넌트에 React.memo 적용
→ 동일 reference 유지 시 카드 렌더링 자체를 스킵

<br />

**`결과`**

최적화 전 : 
SSE 이벤트 발생
→ 전체 리스트 리렌더링
→ Render Duration: 55.1ms

최적화 후 : 
SSE 이벤트 발생
→ 변경된 카드만 렌더링
→ Render Duration: 9.9ms

✅ 약 82% 렌더 성능 개선

<br />

## 💬 메모 ( React Profiler )

<img width="1504" height="956" alt="스크린샷 2026-05-17 오후 7 13 10" src="https://github.com/user-attachments/assets/92e8a6d9-21d2-4771-8229-f5356b35ba86" /> | <img width="1504" height="956" alt="스크린샷 2026-05-17 오후 7 19 24" src="https://github.com/user-attachments/assets/f634f4d5-969d-4eff-9856-65aa8cdb3926" />
---|---|


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **성능 개선**
  * 마이페이지 프로모션 업데이트 처리 방식이 개선되어 프로모션 정보가 더욱 빠르고 효율적으로 실시간 반영됩니다
  * 앨범 카드 렌더링 성능이 최적화되어 페이지 반응성이 향상되었습니다

* **기능 개선**
  * 진단 정보에 진단 수행 시간 데이터가 추가되었습니다

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devTeam-PEAK/FE/pull/146?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->