### PR TITLE
#147 fix: 앨범 커버 이미지 잘림 이슈 수정

### DIFF
--- a/src/components/mypage/album-analysis-page.tsx
+++ b/src/components/mypage/album-analysis-page.tsx
@@ -139,13 +139,13 @@ export default function AlbumAnalysisPage({ promotionId }: Props) {
       <main className="mb-2 flex flex-col gap-7">
         <section className="mb-1 flex flex-col items-center gap-6 px-9">
           <div className="flex flex-col gap-3">
-            <div className="rounded-r2 shrink-0 overflow-hidden">
+            <div className="rounded-r2 h-[126px] w-[126px] shrink-0 overflow-hidden">
               <Image
                 src={analysisData.imageUrl}
                 alt={analysisData.songTitle}
                 width={126}
                 height={126}
-                className="aspect-square object-cover"
+                className="h-full w-full object-cover"
                 loading="eager"
               />
             </div>

--- a/src/components/mypage/album-item-card.tsx
+++ b/src/components/mypage/album-item-card.tsx
@@ -48,13 +48,13 @@ function AlbumItemCard({ album, priority = false }: Props) {
           <div className="bg-danger absolute top-3 left-3 h-2 w-2 rounded-full" />
         )}
 
-        <div className="rounded-r2 shrink-0 overflow-hidden">
+        <div className="rounded-r2 h-30 w-30 shrink-0 overflow-hidden">
           <Image
             src={album.coverImageUrl}
             alt={album.title}
             width={120}
             height={120}
-            className="aspect-square object-cover"
+            className="h-full w-full object-cover"
             priority={priority}
           />
         </div>
@@ -92,7 +92,7 @@ function AlbumItemCard({ album, priority = false }: Props) {
           </div>
 
           {(isNotAnalyzed || isAnalyzing) && (
-            <div className="mt-3" onClick={(e) => e.stopPropagation()}>
+            <div onClick={(e) => e.stopPropagation()}>
               <Button
                 variant="btnPurple"
                 className="p2-bold h-9 rounded-full px-5"


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #147

<br />

## 📝 작업 내용

마이페이지(4.1.2)
앨범 분석 페이지(4.1.3)

위 두 페이지에서 몇몇 앨범 커버 이미지가 잘린 채 나타나는 이슈가 발견되어 수정했습니다.

이미지 wrapper 크기와 실제 이미지 비율이 안 맞아서 발생하는 문제로 보여
wrapper 크기를 강제로 고정하는 방법으로 해결했습니다.

<br />

<img width="377" height="160" alt="image" src="https://github.com/user-attachments/assets/45b2f8dc-3d10-4030-9be1-812f7f264c12" /> | <img width="380" height="367" alt="image" src="https://github.com/user-attachments/assets/47858a2e-1430-42d2-9c38-8006dfd989a2" />
---|---|

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 마이페이지의 앨범 이미지 표시 영역 레이아웃이 개선되어 더 일관된 크기로 표시됩니다.
  * 앨범 진단 버튼의 클릭 동작이 최적화되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devTeam-PEAK/FE/pull/150?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->