### PR TITLE
#154 fix: 앨범 소유자 검증 없이 관리 화면이 노출되는 이슈 수정

### DIFF
--- a/src/app/(logo-header)/album/[id]/page.tsx
+++ b/src/app/(logo-header)/album/[id]/page.tsx
@@ -1,6 +1,7 @@
 import AlbumDetail from "@/components/album/album-detail";
 import AlbumActionButton from "@/components/album/album-action-button";
 import { cookies } from "next/headers";
+import { getMe } from "@/lib/api/auth";
 import { getMusicPromotion } from "@/lib/api/music-promotion";
 import { getStreamingCode } from "@/utils/album";
 import FadeMotion from "@/components/common/fade-motion";
@@ -21,6 +22,18 @@ export default async function AlbumDetailPage({ params, searchParams }: Props) {
   const fromAnalysis = from === "analysis";
 
   const data = await getMusicPromotion(promotionId);
+
+  let isMusician = false; // 앨범 소유자 여부
+
+  // 로그인 되어 있는 유저만 사용자 정보 조회
+  if (isLoggedIn) {
+    try {
+      const me = await getMe();
+      isMusician = me.id === data.musicianId;
+    } catch {
+      isMusician = false;
+    }
+  }
 
   const albumInfo = {
     coverUrl: data.imageUrl,
@@ -49,7 +62,7 @@ export default async function AlbumDetailPage({ params, searchParams }: Props) {
           <AlbumDetail {...albumInfo} />
         </div>
         <div className="mt-auto flex flex-col items-center gap-1">
-          {isLoggedIn ? (
+          {isMusician ? (
             <>
               <span className="c1-medium text-font-light">
                 팬들이 링크를 눌렀을 때 이렇게 보여요.
@@ -71,7 +84,7 @@ export default async function AlbumDetailPage({ params, searchParams }: Props) {
           <AlbumActionButton
             url={data.trackingUrl}
             promotionId={promotionId}
-            isLoggedIn={isLoggedIn}
+            isMusician={isMusician}
             fromAnalysis={fromAnalysis}
           />
         </div>

--- a/src/components/album/album-action-button.tsx
+++ b/src/components/album/album-action-button.tsx
@@ -7,14 +7,14 @@ import { useRouter } from "next/navigation";
 interface Props {
   url: string;
   promotionId: number;
-  isLoggedIn: boolean;
+  isMusician: boolean;
   fromAnalysis: boolean;
 }
 
 export default function AlbumActionButton({
   url,
   promotionId,
-  isLoggedIn,
+  isMusician,
   fromAnalysis,
 }: Props) {
   const router = useRouter();
@@ -24,7 +24,7 @@ export default function AlbumActionButton({
       await navigator.clipboard.writeText(url);
       toast.success("링크가 복사되었습니다!", { position: "bottom-center" });
 
-      if (isLoggedIn) {
+      if (isMusician) {
         router.push("/album/promote");
       }
     } catch {
@@ -54,7 +54,7 @@ export default function AlbumActionButton({
         </Button>
       )}
 
-      {isLoggedIn && (
+      {isMusician && (
         <Button variant="btnPurpleSub" size="md" onClick={handleEdit}>
           수정하기
         </Button>

--- a/src/components/common/header-client.tsx
+++ b/src/components/common/header-client.tsx
@@ -19,7 +19,7 @@ export default function HeaderClient({ isLoggedIn }: Props) {
   return (
     <div className="sticky top-0 z-40 flex h-14 w-full items-center justify-between bg-white">
       <Link href="/">
-        <Image src="/logo.svg" alt="Logo" width={56} height={14} />
+        <Image src="/logo.svg" alt="Logo" width={56} height={14} priority />
       </Link>
 
       {isLoggedIn && !isSettingPage && (

--- a/src/components/common/logo-header.tsx
+++ b/src/components/common/logo-header.tsx
@@ -5,7 +5,13 @@ export default async function LogoHeader() {
   return (
     <div className="sticky top-0 z-999 flex h-14 w-full items-center justify-center bg-white">
       <Link href="/">
-        <Image src={"/full-logo.svg"} alt="Logo" width={104} height={20} />
+        <Image
+          src={"/full-logo.svg"}
+          alt="Logo"
+          width={104}
+          height={20}
+          priority
+        />
       </Link>
     </div>
   );

--- a/src/types/api-response.ts
+++ b/src/types/api-response.ts
@@ -27,6 +27,7 @@ export interface CreateMusicPromotionRes {
 // 뮤지션 홍보 조회 Res
 export interface GetMusicPromotionRes {
   promotionId: number;
+  musicianId: number;
   activityName: string;
   songTitle: string;
   releaseDate: string;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #154

<br />

## 📝 작업 내용

<img width="546" height="622" alt="스크린샷 2026-05-18 오후 1 22 45" src="https://github.com/user-attachments/assets/3fc12492-8d2c-425a-9767-8976cb954826" />

해당 앨범의 소유자(뮤지션)인지는 체크하지 않고, 로그인 여부만 체크하게 되어 있어서
앨범 주인이 아닌데 서비스에 로그인이 되어 있는 상태이기만 해도 관리 화면(왼쪽)이 노출되는 이슈가 발견되었습니다.

뮤지션 홍보 조회 api 응답값으로 musicianId를 받을 수 있도록 백엔드 팀에 요청드리고,
로그인한 유저만 사용자 정보 조회(/me) api를 추가로 호출해 해당 앨범의 소유자인지의 여부를 체크하도록 로직을 수정했습니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 앨범 상세 페이지의 권한 검증 로직을 강화하여 앨범 소유자만 수정 기능에 접근 가능하도록 개선
  * 앨범 작업 버튼의 표시 및 동작 조건을 정확히 조정

* **기술 개선**
  * 로고 이미지 로딩 성능 최적화
  * API 응답 구조 확장으로 뮤지션 식별 정보 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devTeam-PEAK/FE/pull/156?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->