### PR TITLE
#157 fix: 모바일 배포 환경에서 캘린더 모달 취소/확인 버튼 깨짐 이슈

### DIFF
--- a/src/components/common/calendar-input.tsx
+++ b/src/components/common/calendar-input.tsx
@@ -75,7 +75,7 @@ export default function CalendarInput({
       </DialogTrigger>
 
       <DialogContent
-        className="max-w-2xs p-0"
+        className="flex max-w-2xs flex-col p-0"
         showCloseButton={false}
         aria-describedby={undefined}
       >
@@ -88,18 +88,18 @@ export default function CalendarInput({
           mode="single"
           selected={tempDate}
           onSelect={setTempDate}
-          className="flex w-full"
+          className="w-full"
           classNames={{
             months:
               "flex flex-col sm:flex-row space-y-4 sm:space-x-4 sm:space-y-0 flex-1",
             month: "space-y-4 w-full flex flex-col",
-            table: "w-full h-full border-collapse space-y-1",
+            table: "w-full border-collapse space-y-1",
             head_row: "",
             row: "w-full mt-2",
           }}
         />
 
-        <DialogFooter>
+        <DialogFooter className="px-4 pt-2 pb-4">
           <Button variant="btnWhite" size="mini" onClick={handleCancel}>
             취소
           </Button>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #157 

<br />

## 📝 작업 내용

<img width="200" height="500" alt="image" src="https://github.com/user-attachments/assets/20070646-67ed-427f-b4ed-01a4ec39e655" />

calendar dialog footer 레이아웃 깨지는 이슈 수정했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 캘린더 입력 다이얼로그의 레이아웃을 개선하여 표시 방식을 최적화했습니다.
  * 다이얼로그 푸터의 패딩을 조정했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devTeam-PEAK/FE/pull/158?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->