### PR TITLE
#162 fix: iOS 포커스 시 줌인 방지를 위한 viewport maximumScale 설정

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import Script from "next/script";
 import { pretendard, poppins } from "./fonts/fonts";
 import "./globals.css";
@@ -9,6 +9,12 @@ import MailSuccessModal from "@/components/common/mail-success-modal";
 import AuthErrorModal from "@/components/common/auth-error-modal";
 import ToastProvider from "@/components/ui/toast-provider";
 import QueryProvider from "@/components/common/query-provider";
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  maximumScale: 1,
+};
 
 export const metadata: Metadata = {
   metadataBase: new URL("https://www.musicpeak.site"),


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex. #162 

<br />

## 📝 작업 내용

> 문제

<img width="1650" height="1061" alt="스크린샷 2026-05-18 오후 10 15 14" src="https://github.com/user-attachments/assets/8ef538cc-01a8-45d9-9e52-0d6d29aa4919" />

https://www.notion.so/goormkdx/360c0ff4ce318004b907c132d7110bd0?source=copy_link

ios 에서 폰트 16px이하가 되어버리면 포커스시에 줌인시켜버리는 문제발견 ( 아마도 접근성때문인걸로 추측 )

> 해결

### 변경 사항

- `src/app/layout.tsx`에 `viewport` export 추가
- `maximumScale: 1` 설정으로 iOS Safari에서 input/textarea 포커스 시 자동 줌인 방지

### 원인

iOS Safari는 font-size가 16px 미만인 input에 포커스될 때 자동으로 페이지를 줌인합니다. `maximum-scale=1`을 viewport에 설정하면 이를 방지할 수 있습니다.

### 참고

Next.js App Router에서는 `<meta>` 태그를 직접 작성하는 대신 `viewport` export를 사용해야 합니다. (`metadata`에 포함시키면 빌드 경고 발생)


<br />

## 💬 리뷰 요구사항 ( 선택 )

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 <br />
> ex. 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 개선사항
* 뷰포트 설정을 명시적으로 구성하여 모든 기기에서 최적의 화면 표시 보장
  * 화면 너비와 스케일 설정을 정의하여 일관된 사용자 경험 제공

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devTeam-PEAK/FE/pull/163?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->